### PR TITLE
fix: correct q11 normalization in get_Q_block (γ**3 → γ**2)

### DIFF
--- a/python/argus/model.py
+++ b/python/argus/model.py
@@ -53,8 +53,15 @@ def get_Q_block(γ: float, dt: float) -> jax.Array:
     one_minus_exp_term = -jnp.expm1(neg_gamma_dt)
     one_minus_exp_2term = -jnp.expm1(neg_2gamma_dt)
 
-    # Calculate terms assuming gamma != 0
-    q11 = (dt - 2 * one_minus_exp_term / γ + one_minus_exp_2term / (2 * γ)) / γ**3
+    # Calculate terms assuming gamma != 0.
+    #
+    # These are the exact process-noise (co)variances for the integrated-OU state
+    # (x, v) with dx = v dt, dv = -γ v dt + dW (unit-PSD driving noise), i.e.
+    # Q = ∫_0^dt e^{Aτ} B Bᵀ e^{Aᵀτ} dτ with A = [[0, 1], [0, -γ]], B = [0, 1]ᵀ and
+    # e^{Aτ}B = [(1-e^{-γτ})/γ, e^{-γτ}]ᵀ. The position variance is therefore
+    #   q11 = ∫_0^dt [(1-e^{-γτ})/γ]² dτ = [dt - 2(1-e^{-γdt})/γ + (1-e^{-2γdt})/(2γ)] / γ²
+    # (small-γdt limit → dt³/3, matching the double-integrated white-noise result).
+    q11 = (dt - 2 * one_minus_exp_term / γ + one_minus_exp_2term / (2 * γ)) / γ**2
     q12 = (one_minus_exp_term - one_minus_exp_2term / 2) / (γ**2)
     q22 = one_minus_exp_2term / (2 * γ)
 

--- a/test/test_likelihood_value.py
+++ b/test/test_likelihood_value.py
@@ -86,9 +86,11 @@ def test_likelihood_value():
 
     print("the computed log likelihood is:", log_likelihood)
 
-    # Assert expected value - using a placeholder value that should be updated
-    # based on actual test runs with the specific dataset
-    expected_likelihood = 55963.86  # Approximate expected value
+    # Assert expected value - a golden value recorded from an actual run on this
+    # dataset (γa=1e-9, ha=1e-15, 32 MDC2 pulsars). Updated from 55963.86 after the
+    # get_Q_block q11 fix (γ**3 -> γ**2): correcting the integrated-OU position-noise
+    # normalization shifts the log-likelihood by ~7655 nats.
+    expected_likelihood = 63618.93  # Golden value (post q11 fix)
 
     # Use relative tolerance for floating point comparison
     assert (

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -96,6 +96,30 @@ class TestQBlock:
         assert Q[0, 0] < 1e-10
         assert Q[1, 1] < 1e-5
 
+    def test_q11_matches_exact_integrated_ou(self):
+        """q11 must equal the exact integrated-OU position variance (regression).
+
+        For the state (x, v) with dx = v dt, dv = -γ v dt + dW (unit-PSD noise),
+        q11 = ∫_0^dt [(1-e^{-γτ})/γ]² dτ. This pins the γ**2 normalization: a γ**3
+        typo inflates q11 by a factor 1/γ, which for PTA-scale γ ~ 1e-9 is a ~1e9
+        error in the GW/red-noise process noise. Compared against an independent
+        numerical quadrature (robust to the closed form's cancellation at small γdt).
+        """
+        for γ, dt in [(1e-8, 30 * 86400.0), (1e-9, 30 * 86400.0), (2.0, 0.5)]:
+            q11 = float(model.get_Q_block(γ, dt)[0, 0])
+            τ = np.linspace(0.0, dt, 400_001)
+            quad = float(np.trapz(((1 - np.exp(-γ * τ)) / γ) ** 2, τ))
+
+            assert np.isclose(q11, quad, rtol=1e-4)
+            # The γ**3 typo would put q11 a factor 1/γ above the true value.
+            assert not np.isclose(q11, quad / γ, rtol=1e-2)
+
+    def test_q11_small_dt_cubic_limit(self):
+        """For γ·dt << 1 the position variance approaches the dt³/3 white-noise result."""
+        γ, dt = 1e-3, 1.0  # γ·dt = 1e-3: small enough for dt³/3, mild cancellation
+        q11 = float(model.get_Q_block(γ, dt)[0, 0])
+        assert np.isclose(q11, dt**3 / 3.0, rtol=2e-3)
+
 
 class TestFSpin:
     """Tests for get_F_spin function."""


### PR DESCRIPTION
## Summary

`get_Q_block` computes the discrete process-noise covariance for the integrated-OU
state `(x, v)` (`dx = v dt`, `dv = -γ v dt + dW`) used for both the GWB residual
state and per-pulsar red noise. The position-variance term `q11` was divided by
`γ**3` instead of `γ**2`, inflating it by a factor `1/γ`. At PTA-scale corner rates
(`γ ~ 1e-9 s⁻¹`) that is a ~1e9 error in the `r`-state (and red-noise) process noise,
which loosens the Kalman filter's dynamical prior on the GW-induced residual and
biases the recovered background amplitude.

## The fix

`q11` is the exact integral `∫₀^dt [(1-e^{-γτ})/γ]² dτ`, whose closed form divides
the bracket `[dt - 2(1-e^{-γdt})/γ + (1-e^{-2γdt})/(2γ)]` by `γ**2` (small-`γdt`
limit → `dt³/3`, the double-integrated white-noise result). Changed `/ γ**3` →
`/ γ**2`. `q12` and `q22` were already correct.

Verified three independent ways: series expansion, direct numerical quadrature of the
defining integral, and the `dt³/3` limit.

## Impact & validation

- Added regression tests (`test/test_model.py`) pinning `q11` to numerical quadrature
  and the `dt³/3` limit.
- Updated the MDC2 golden log-likelihood in `test/test_likelihood_value.py`
  (55963.86 → 63618.93) — a ~7655-nat shift, reflecting the corrected `Q`.
- Full suite: **234 passed, 1 skipped**.
- MDC2 GWB+HD+NUTS recovery on A100 converges cleanly with the fix (0 divergences,
  `r_hat` 1.00–1.01, well-defined interior posterior).

Note: because the fix changes the `ha`→residual-amplitude scaling (r-noise now
`∝ ha²·γa`), the recovered `log10_ha` on MDC2 shifts (≈ −15.5 → −12.9); downstream
`log10_ha` priors should be re-centred accordingly.

