### PR TITLE
fix: guard Kalman log-likelihood against near-singular innovation covariance

### DIFF
--- a/python/argus/jax_kalman_filter.py
+++ b/python/argus/jax_kalman_filter.py
@@ -107,9 +107,21 @@ def _log_likelihood(y: jax.Array, cov: jax.Array) -> jax.Array:
     -------
         float: Log likelihood value
     """
+    # Robustness against a near-singular innovation covariance. A global sampler (e.g. nested
+    # sampling) explores prior tails where `cov` can go numerically near-singular; then a raw
+    # slogdet runs to -inf and, if the innovation misses the near-zero-variance direction, the
+    # likelihood spikes to a spurious huge positive value that the sampler locks onto. We
+    # symmetrise and add a jitter scaled to the matrix magnitude (negligible when `cov` is
+    # well-conditioned, so gradient-guided samplers and the golden likelihood are unchanged),
+    # and reject any residually non-positive-definite `cov` rather than return garbage.
+    n = cov.shape[0]
+    cov = 0.5 * (cov + cov.T)
+    jitter = 1e-9 * (jnp.trace(cov) / n)
+    cov = cov + jitter * jnp.eye(n)
     sign, logdet = jnp.linalg.slogdet(2.0 * jnp.pi * cov)
     quadratic_term = y.T @ jnp.linalg.solve(cov, y)
-    return -0.5 * (logdet + quadratic_term)
+    ll = -0.5 * (logdet + quadratic_term)
+    return jnp.where(sign > 0, ll, -jnp.inf)
 
 
 @partial(jax.jit, static_argnums=(4,))


### PR DESCRIPTION
## Summary
Hardens `_log_likelihood` in `jax_kalman_filter.py` against a near-singular
innovation covariance `S`.

## Problem
`_log_likelihood` used a raw `slogdet` + `solve` on `S` and ignored the `slogdet`
sign. A global sampler (nested sampling) explores prior tails where `S` can go
numerically near-singular — triggered by high-precision pulsars (e.g. J0437-4715)
whose tiny measurement noise makes `S` easy to ill-condition. There `slogdet`
runs to `-inf`, and if the innovation misses the near-zero-variance direction the
likelihood spikes to a spurious **huge positive** value that the sampler locks
onto (observed ~8.6e8). NUTS never hits this — its gradients keep it in the
typical set — so this only surfaced with a global sampler.

## Fix
- Symmetrise `S`.
- Add a magnitude-relative jitter `1e-9 * trace(S)/n` on the diagonal, flooring
  the eigenvalues so `slogdet` cannot run to `-inf`. Negligible for
  well-conditioned `S`.
- Reject any residually non-positive-definite `S` (`sign <= 0`) by returning
  `-inf` instead of garbage.

## Validation
- Previously-pathological config: tail log-likelihood **8.6e8 → bounded** (max
  now at the true mode near the center).
- **Golden likelihood 63618.93 preserved**; `test_likelihood_value.py` +
  `test_jax_kalman_filter.py` pass (18 tests) on `main`.
- NUTS results unchanged: the jitter is negligible for well-conditioned `S`, and
  NUTS never visits the ill-conditioned tail regions.

