### PR TITLE
feat: square-root parallel (associative-scan) Kalman filter [#103 PR1]

### DIFF
--- a/python/argus/jax_kalman_filter.py
+++ b/python/argus/jax_kalman_filter.py
@@ -7,7 +7,7 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 from jax import lax
-from jax.scipy.linalg import block_diag
+from jax.scipy.linalg import block_diag, solve_triangular
 from typing import Tuple
 
 
@@ -610,6 +610,373 @@ def _run_kalman_filter_marginal(
     return logL
 
 
+# ---------------------------------------------------------------------------
+# Square-root temporally-parallel (associative-scan) Kalman filter.
+#
+# Numerically-stable, autodiff-safe replacement for the parked standard-form
+# associative scan (issue #103 PR1). The parked filter lost positive-definiteness
+# of the filtered COVARIANCE under the array's 1e-40 dynamic range (the
+# `(I + C_i J_j)⁻¹` combination developed negative eigenvalues → logL = -inf).
+#
+# We therefore carry the covariance block C = U Uᵀ in square-root (Cholesky
+# factor) form — U is what must stay PSD — but keep the information block J as a
+# plain symmetric matrix. Element/operator follow Särkkä & García-Fernández
+# (2021, arXiv:1905.13002); the square-root covariance combination is derived via
+# the Woodbury identity
+#     (I + C_i J_j)⁻¹ C_i = U_i M⁻¹ U_iᵀ ,   M = I + U_iᵀ J_j U_i  (PD, ⪰ I)
+# so the combined covariance factor U_new = tria([A_j U_i M⁻ᵀᐟ² | U_j]) is a QR
+# of a *full-rank* horizontal stack of PSD terms (no subtraction → PSD by
+# construction), and the only matrix inverse is a Cholesky solve against M ⪰ I
+# (perfectly conditioned regardless of the 1e-40 scaling).
+#
+# Why not also factor J (as the Yaghoobi et al. 2021 fully-square-root filter
+# does): J = Σ (HF)ᵀS⁻¹(HF) is genuinely low-rank early in the scan, so its
+# factor Z must be zero-padded to a fixed shape — and JAX's QR reverse-mode
+# divides by zero on the resulting rank-deficient pre-arrays, giving NaN
+# gradients (NUTS needs gradients). Keeping J plain makes every QR here
+# full-rank, so gradients flow. J only ever enters through M = I + Uᵀ J U, whose
+# conditioning is immune to J being ill-scaled or slightly indefinite.
+# ---------------------------------------------------------------------------
+
+
+def _tria(X):
+    """Lower-triangular factor L with L Lᵀ = X Xᵀ, via the reduced QR of Xᵀ.
+
+    `X` has shape (p, q) with q >= p (rows are variables, columns are the
+    stacked pre-array). Returns L of shape (p, p). The sign of the QR diagonal
+    is irrelevant since only L Lᵀ is used downstream.
+    """
+    R = jnp.linalg.qr(X.T, mode="reduced")[1]  # (p, p) upper-triangular
+    return R.T
+
+
+def _chol_psd(M):
+    """Lower-triangular Cholesky factor L with L Lᵀ = M, for PD M.
+
+    Cholesky (not eigh) is used deliberately: the prior covariance and process
+    noise span ~1e-40..1e-23, and an eigendecomposition cannot resolve the
+    1e-40 position-variance entries (they fall below the noise floor of the
+    ~1e-23 largest eigenvalue), whereas Cholesky computes each pivot from its
+    own local scale and preserves the hierarchy. A magnitude-relative jitter far
+    below the smallest structural entry guards a marginally-indefinite input
+    without perturbing the 1e-40 scale.
+    """
+    n = M.shape[0]
+    M = 0.5 * (M + M.T)
+    jitter = 1e-30 * jnp.trace(M) / n
+    return jnp.linalg.cholesky(M + jitter * jnp.eye(n))
+
+
+def _sqrt_first_filtering_element(x0, L_P0, H, L_R, z):
+    """Square-root filtering element for epoch 0 (update-only against the prior).
+
+    `L_P0 L_P0ᵀ = P0` (prior cov), `L_R L_Rᵀ = R`. Returns (A, b, U, eta, J) with
+    A, eta, J zero (no preceding transition) and (b, U) the prior updated on the
+    first observation. `U Uᵀ = (I - K H) P0` is read straight off the QR of the
+    measurement pre-array, so it is PSD by construction.
+    """
+    d = x0.shape[0]
+    m = L_R.shape[0]
+    # Pre-array [[L_R, H L_P0], [0, L_P0]] -> tria gives [[S^{1/2}, 0], [K S^{1/2}, U]].
+    top = jnp.concatenate([L_R, H @ L_P0], axis=1)
+    bot = jnp.concatenate([jnp.zeros((d, m)), L_P0], axis=1)
+    L = _tria(jnp.concatenate([top, bot], axis=0))
+    L11 = L[:m, :m]
+    L21 = L[m:, :m]
+    U = L[m:, m:]
+    # K = L21 L11^{-1}: solve L11ᵀ Kᵀ = L21ᵀ (L11ᵀ upper-triangular).
+    K = solve_triangular(L11.T, L21.T, lower=False).T
+    b = x0 + K @ (z[:, None] - H @ x0)
+    A = jnp.zeros((d, d))
+    eta = jnp.zeros((d, 1))
+    J = jnp.zeros((d, d))
+    return A, b, U, eta, J
+
+
+def _sqrt_generic_filtering_element(F, L_Q, H, L_R, z):
+    """Square-root filtering element for a predict+update epoch.
+
+    `L_Q L_Qᵀ = Q` (process noise), `L_R L_Rᵀ = R`. Encodes transition (F, Q)
+    then update (H, R, z). Returns (A, b, U, eta, J) with U Uᵀ = C = (I-KH)Q the
+    Cholesky factor of the covariance block and J = (H F)ᵀ S⁻¹ (H F) the plain
+    (d, d) symmetric information block.
+    """
+    d = F.shape[0]
+    m = L_R.shape[0]
+    # Measurement-update array with Q as the "predicted" covariance.
+    top = jnp.concatenate([L_R, H @ L_Q], axis=1)
+    bot = jnp.concatenate([jnp.zeros((d, m)), L_Q], axis=1)
+    L = _tria(jnp.concatenate([top, bot], axis=0))
+    L11 = L[:m, :m]  # S^{1/2}
+    L21 = L[m:, :m]  # K S^{1/2}
+    U = L[m:, m:]  # C^{1/2}
+
+    K = solve_triangular(L11.T, L21.T, lower=False).T
+    I_KH = jnp.eye(d) - K @ H
+    A = I_KH @ F
+    b = K @ z[:, None]
+
+    HF = H @ F
+    # eta = (HF)ᵀ S⁻¹ z  via two triangular solves against S^{1/2} = L11.
+    w = solve_triangular(L11, z[:, None], lower=True)
+    Sinv_z = solve_triangular(L11.T, w, lower=False)
+    eta = HF.T @ Sinv_z
+    # J = (HF)ᵀ S⁻¹ (HF) = GᵀG with G = L11⁻¹ (HF); kept as a plain matrix.
+    G = solve_triangular(L11, HF, lower=True)
+    J = G.T @ G
+    return A, b, U, eta, J
+
+
+def _sqrt_filtering_operator(elem_i, elem_j):
+    """Associative combination of two square-root filtering elements (i precedes j).
+
+    Square-root (covariance-factored, information-plain) form of Särkkä &
+    García-Fernández (2021) eq. 17. Passed to `jax.lax.associative_scan` via
+    `jax.vmap`, so this operates on single (2-D) elements and vmap supplies the
+    leading segment axis.
+    """
+    A_i, b_i, U_i, eta_i, J_i = elem_i
+    A_j, b_j, U_j, eta_j, J_j = elem_j
+    d = A_i.shape[0]
+    Id = jnp.eye(d)
+
+    # M = I + U_iᵀ J_j U_i  (PD, ⪰ I); Lam Lamᵀ = M.
+    UtJ = U_i.T @ J_j  # (d, d)
+    M = Id + UtJ @ U_i
+    Lam = jnp.linalg.cholesky(0.5 * (M + M.T))
+
+    def Minv(X):  # M⁻¹ X via two triangular solves against Lam.
+        return solve_triangular(
+            Lam.T, solve_triangular(Lam, X, lower=True), lower=False
+        )
+
+    # (I + C_i J_j)⁻¹ C_i = U_i M⁻¹ U_iᵀ = P Pᵀ, P = U_i Lam⁻ᵀ.
+    P = solve_triangular(Lam, U_i.T, lower=True).T
+    # G = (I + C_i J_j)⁻¹ = I - U_i M⁻¹ (U_iᵀ J_j); Gp = (I + J_j C_i)⁻¹.
+    G = Id - U_i @ Minv(UtJ)
+    Gp = Id - (J_j @ U_i) @ Minv(U_i.T)
+
+    A = A_j @ G @ A_i
+    # C_i eta_j = U_i (U_iᵀ eta_j).
+    b = A_j @ (G @ (b_i + U_i @ (U_i.T @ eta_j))) + b_j
+    eta = A_i.T @ (Gp @ (eta_j - J_j @ b_i)) + eta_i
+
+    # C_new = (A_j P)(A_j P)ᵀ + U_j U_jᵀ  -> QR of a full-rank stack (PSD, no subtraction).
+    U = _tria(jnp.concatenate([A_j @ P, U_j], axis=1))
+    # J_new = A_iᵀ [(I + J_j C_i)⁻¹ J_j] A_i + J_i, with (I+J_jC_i)⁻¹J_j = J_j - Y M⁻¹ Yᵀ.
+    Y = J_j @ U_i
+    Jterm = J_j - Y @ Minv(Y.T)
+    J = A_i.T @ Jterm @ A_i + J_i
+    J = 0.5 * (J + J.T)
+    return A, b, U, eta, J
+
+
+def _sqrt_parallel_filter(x0, L_P0, F_all, L_Q_all, H_dyn_all, L_R_all, data):
+    """Square-root associative-scan Kalman filter over the dynamic state.
+
+    Builds per-epoch square-root filtering elements (epoch 0 update-only, the
+    rest predict+update) and combines them with `_sqrt_filtering_operator` under
+    `jax.lax.associative_scan` in O(log T) depth. Returns the filtered mean
+    `m_filt` (T, d, 1) and filtered-covariance Cholesky factor `U_filt` (T, d, d)
+    with P_k = U_k U_kᵀ. All covariances/process-noise are supplied as factors
+    (`L_P0`, `L_Q_all`, `L_R_all`) so positive-definiteness is preserved.
+    """
+    e0 = _sqrt_first_filtering_element(x0, L_P0, H_dyn_all[0], L_R_all[0], data[0])
+    e_rest = jax.vmap(_sqrt_generic_filtering_element)(
+        F_all, L_Q_all, H_dyn_all[1:], L_R_all[1:], data[1:]
+    )
+    elements = tuple(
+        jnp.concatenate([e0_leaf[None, ...], rest_leaf], axis=0)
+        for e0_leaf, rest_leaf in zip(e0, e_rest)
+    )
+    _, b_filt, U_filt, _, _ = lax.associative_scan(
+        jax.vmap(_sqrt_filtering_operator), elements
+    )
+    return b_filt, U_filt
+
+
+def _run_sqrt_dynamic_filter(
+    θ,
+    data,
+    data_errors,
+    H_dyn_all,
+    Npsr,
+    M_sum,
+    hellings_downs_matrix,
+    dt_array,
+    dim_x,
+):
+    """STAGE-0 spike: square-root parallel Kalman filter over the dynamic state only.
+
+    Produces per-epoch filtered mean `m_filt` (T, d, 1) and filtered-covariance
+    Cholesky factor `U_filt` (T, d, d) with P_k = U_k U_kᵀ, for the d = 4*Npsr
+    dynamic (GW+spin) state — no timing-model sensitivity Ξ, no marginalization.
+    This isolates the numerical question: does the square-root associative scan
+    stay PSD and match the sequential dynamic filter on the real (1e-40 dynamic
+    range) MDC2 array?
+    """
+    σa2 = _compute_sigma_matrix(θ.ha**2, θ.γa, hellings_downs_matrix)
+    x0, P0 = _initialize_dynamic_kalman_filter(Npsr, σa2, θ.γa, θ.σp**2, θ.γp)
+    L_P0 = _chol_psd(P0)
+
+    R_matrices = precompute_R_matrices(data_errors, θ.EFAC, θ.EQUAD)
+    L_R_all = jnp.sqrt(R_matrices)  # R is diagonal -> factor is elementwise sqrt
+
+    dt_indices = jnp.arange(len(data) - 1)
+    (F_gw_all, F_spin_all), (Q_gw_all, Q_spin_all) = _precompute_transition_matrices(
+        θ.γa, θ.γp, σa2, θ.σp**2, dt_array[dt_indices], Npsr, M_sum
+    )
+    F_all = jax.vmap(block_diag)(F_gw_all, F_spin_all)
+    Q_all = jax.vmap(block_diag)(Q_gw_all, Q_spin_all)
+    L_Q_all = jax.vmap(_chol_psd)(Q_all)
+
+    return _sqrt_parallel_filter(x0, L_P0, F_all, L_Q_all, H_dyn_all, L_R_all, data)
+
+
+def _affine_compose(elem_i, elem_j):
+    """Compose two affine maps g(x)=M x + N (i precedes j): returns (M_j M_i, M_j N_i + N_j)."""
+    M_i, N_i = elem_i
+    M_j, N_j = elem_j
+    return M_j @ M_i, M_j @ N_i + N_j
+
+
+@jax.named_call
+@partial(jax.jit, static_argnames=("Npsr", "M_sum", "dim_x", "n_states", "diffuse"))
+def _run_kalman_filter_marginal_parallel(
+    θ,
+    data,
+    data_errors,
+    H_matrices,
+    Npsr,
+    M_sum,
+    hellings_downs_matrix,
+    dt_array,
+    dim_x,
+    n_states,
+    P_eps_inv,
+    diffuse=False,
+):
+    """Temporally-parallel (square-root associative-scan) marginalized Kalman filter.
+
+    Same marginal log likelihood as `_run_kalman_filter_marginal` (analytic
+    Rao-Blackwellization of the timing-model parameters β), but the O(T)
+    sequential recursion is replaced by O(log T)-depth parallel scans:
+
+      Pass 1  square-root parallel filter over the dynamic state -> filtered
+              mean m_k and covariance factor U_k (P_k = U_k U_kᵀ) at every epoch;
+      Pass 2a vmap recompute of the per-epoch predicted mean/cov, innovation
+              covariance S_k, gain K_k, β=0 innovation ỹ_k, and the affine
+              coefficients M_k=(I-K_k H_dyn,k)F_k, N_k=-K_k H_eps,k of the
+              sensitivity recursion (S_k, K_k, P_k are β-independent);
+      Pass 2b a second associative scan composing the affine maps to get the
+              filtered sensitivity Ξ_filt,k, then Ξ_pred,k = F_k Ξ_filt,k-1;
+      Pass 3  reduce the per-epoch information contributions A,b,c,L.
+
+    The final marginalization over β is identical to the sequential filter.
+    Equal to the golden likelihood in exact arithmetic.
+    """
+    σa2 = _compute_sigma_matrix(θ.ha**2, θ.γa, hellings_downs_matrix)
+    x0, P0 = _initialize_dynamic_kalman_filter(Npsr, σa2, θ.γa, θ.σp**2, θ.γp)
+    L_P0 = _chol_psd(P0)
+
+    R_matrices = precompute_R_matrices(data_errors, θ.EFAC, θ.EQUAD)
+    L_R_all = jnp.sqrt(R_matrices)
+
+    dt_indices = jnp.arange(len(data) - 1)
+    (F_gw_all, F_spin_all), (Q_gw_all, Q_spin_all) = _precompute_transition_matrices(
+        θ.γa, θ.γp, σa2, θ.σp**2, dt_array[dt_indices], Npsr, M_sum
+    )
+    F_all = jax.vmap(block_diag)(F_gw_all, F_spin_all)  # (T-1, d, d)
+    Q_all = jax.vmap(block_diag)(Q_gw_all, Q_spin_all)
+    L_Q_all = jax.vmap(_chol_psd)(Q_all)
+
+    n_dyn = 4 * Npsr
+    H_dyn_all = H_matrices[:, :, :n_dyn]
+    H_eps_all = H_matrices[:, :, n_dyn:]
+    d = n_dyn
+
+    # --- Pass 1: square-root parallel filter -> filtered m_k, U_k. ---
+    m_filt, U_filt = _sqrt_parallel_filter(
+        x0, L_P0, F_all, L_Q_all, H_dyn_all, L_R_all, data
+    )
+    P_filt = jnp.matmul(U_filt, jnp.swapaxes(U_filt, -1, -2))  # (T, d, d)
+
+    # --- Pass 2a: per-epoch predicted mean/cov (epoch 0 = prior). ---
+    m_pred = jnp.concatenate(
+        [x0[None], jnp.matmul(F_all, m_filt[:-1])], axis=0
+    )  # (T, d, 1)
+    FPFt = jnp.matmul(jnp.matmul(F_all, P_filt[:-1]), jnp.swapaxes(F_all, -1, -2))
+    P_pred = jnp.concatenate([P0[None], FPFt + Q_all], axis=0)  # (T, d, d)
+
+    def per_epoch_predict(H_dyn, H_eps, R, z, mp, Pp, F):
+        # Innovation covariance with the same symmetrise + jitter + PD policy as
+        # `_update_marginal`, so the log-det stream matches the sequential filter.
+        S = H_dyn @ Pp @ H_dyn.T + R
+        n = S.shape[0]
+        S = 0.5 * (S + S.T)
+        jitter = 1e-9 * (jnp.trace(S) / n)
+        S = S + jitter * jnp.eye(n)
+        sign, logdet = jnp.linalg.slogdet(2.0 * jnp.pi * S)
+        Sinv = jnp.linalg.solve(S, jnp.eye(n))
+        K = Pp @ H_dyn.T @ Sinv
+        y0 = z[:, None] - H_dyn @ mp
+        M = (jnp.eye(d) - K @ H_dyn) @ F  # affine coeff for Ξ (epoch>=1)
+        N = -K @ H_eps
+        dL = jnp.where(sign > 0, logdet, jnp.inf)
+        return Sinv, y0, M, N, dL
+
+    # F into epoch k is F_all[k-1]; epoch 0 has no predecessor (M_0 set to 0 below).
+    F_into = jnp.concatenate([jnp.zeros((1, d, d)), F_all], axis=0)  # (T, d, d)
+    Sinv_all, y0_all, M_all, N_all, dL_all = jax.vmap(per_epoch_predict)(
+        H_dyn_all, H_eps_all, R_matrices, data, m_pred, P_pred, F_into
+    )
+    # Epoch 0 is update-only: Ξ_filt,0 = N_0 (no predecessor), so zero its map.
+    M_all = M_all.at[0].set(jnp.zeros((d, d)))
+
+    # --- Pass 2b: affine associative scan for the filtered sensitivity Ξ. ---
+    _, Xi_filt = lax.associative_scan(jax.vmap(_affine_compose), (M_all, N_all))
+    # Predicted sensitivity: Ξ_pred,0 = 0; Ξ_pred,k = F_k Ξ_filt,k-1.
+    Xi_pred = jnp.concatenate(
+        [jnp.zeros((1, d, M_sum)), jnp.matmul(F_all, Xi_filt[:-1])], axis=0
+    )
+
+    # --- Pass 3: reduce the epsilon information contributions. ---
+    def per_epoch_info(H_dyn, H_eps, Sinv, y0, Xi_p):
+        Psi = H_eps + H_dyn @ Xi_p  # (m, M_sum)
+        Sinv_Psi = Sinv @ Psi
+        Sinv_y0 = Sinv @ y0
+        dA = Psi.T @ Sinv_Psi
+        db = Psi.T @ Sinv_y0
+        dc = (y0.T @ Sinv_y0)[0, 0]
+        return dA, db, dc
+
+    dA_all, db_all, dc_all = jax.vmap(per_epoch_info)(
+        H_dyn_all, H_eps_all, Sinv_all, y0_all, Xi_pred
+    )
+    A = jnp.sum(dA_all, axis=0)
+    b = jnp.sum(db_all, axis=0)
+    c = jnp.sum(dc_all, axis=0)
+    L = jnp.sum(dL_all, axis=0)
+
+    # --- Final marginalization of β (identical to the sequential filter). ---
+    if diffuse:
+        n = A.shape[0]
+        Lambda = 0.5 * (A + A.T)
+        jitter = 1e-9 * (jnp.trace(Lambda) / n)
+        Lambda = Lambda + jitter * jnp.eye(n)
+        sign, logdet_Lambda = jnp.linalg.slogdet(Lambda)
+        bLb = (b.T @ jnp.linalg.solve(Lambda, b))[0, 0]
+        logL = -0.5 * (c + L - bLb + logdet_Lambda)
+        return jnp.where(sign > 0, logL, -jnp.inf)
+
+    Lambda = P_eps_inv + A
+    _, logdet_Lambda = jnp.linalg.slogdet(Lambda)
+    _, logdet_P_eps_inv = jnp.linalg.slogdet(P_eps_inv)
+    bLb = (b.T @ jnp.linalg.solve(Lambda, b))[0, 0]
+    logL = -0.5 * (c + L - bLb + logdet_Lambda - logdet_P_eps_inv)
+    return logL
+
+
 class JaxKalmanFilter:
     """A class to implement the linear Kalman filter on scalar inputs using JAX.
 
@@ -631,6 +998,7 @@ class JaxKalmanFilter:
         use_marginal: bool = True,
         timing_prior: str = "informative",
         prior_scale: float = 1.0,
+        use_parallel: bool = False,
     ):
         """Initialize the class.
 
@@ -653,6 +1021,13 @@ class JaxKalmanFilter:
                 (P_eps → α·P_eps, P_eps⁻¹ → P_eps⁻¹/α). Default 1.0 reproduces the golden
                 likelihood; large α weakens the prior toward the diffuse limit. Ignored when
                 timing_prior="diffuse".
+            use_parallel: If True, use the temporally-parallel square-root
+                associative-scan implementation of the marginal filter
+                (`_run_kalman_filter_marginal_parallel`) instead of the sequential
+                `lax.scan`. Same log likelihood (reproduces the golden value), but the
+                O(T) recursion becomes O(log T) depth via `jax.lax.associative_scan`,
+                which parallelises across epochs on GPU. Only supported on the marginal
+                backend (requires use_marginal=True). Default False.
         """
         get_logger().info("Initializing JaxKalmanFilter...")
 
@@ -666,7 +1041,14 @@ class JaxKalmanFilter:
                 "(use_marginal=True); the augmented-state filter cannot represent a flat "
                 "timing-model prior without hitting the near-singular P0 pathology."
             )
+        if use_parallel and not use_marginal:
+            raise ValueError(
+                "use_parallel=True is only supported on the marginalized filter "
+                "(use_marginal=True); the temporally-parallel square-root scan is "
+                "implemented for the marginal backend."
+            )
         self.timing_prior = timing_prior
+        self.use_parallel = use_parallel
 
         observations = data["processed_residuals"]
         df_psr = data["metadata"]
@@ -773,6 +1155,21 @@ class JaxKalmanFilter:
 
     def get_likelihood(self, θ):
         """Run the Kalman filter algorithm over all observations and return a log likelihood."""
+        if self.use_marginal and self.use_parallel:
+            return _run_kalman_filter_marginal_parallel(
+                θ=θ,
+                data=self.jax_data,
+                data_errors=self.jax_data_errors,
+                H_matrices=self.jax_H_matrices,
+                Npsr=self.Npsr,
+                M_sum=self.M_sum,
+                hellings_downs_matrix=self.hellings_downs_matrix,
+                dt_array=self.jax_t_diffs,
+                dim_x=2 * self.Npsr,
+                n_states=self.nx,
+                P_eps_inv=self.P_eps_inv,
+                diffuse=(self.timing_prior == "diffuse"),
+            )
         if self.use_marginal:
             return _run_kalman_filter_marginal(
                 θ=θ,

--- a/python/argus/workflow.py
+++ b/python/argus/workflow.py
@@ -80,15 +80,18 @@ def setup_data_and_kalman_filter(config, logger, use_gw, signal_model="gwb"):
             "PriorModel", "timing_prior", fallback="informative"
         ).strip()
         prior_scale = config.getfloat("PriorModel", "prior_scale", fallback=1.0)
+        use_parallel = config.getboolean("PriorModel", "use_parallel", fallback=False)
         logger.info(
             f"Initializing joint GWB Kalman filter "
-            f"(timing_prior={timing_prior}, prior_scale={prior_scale})..."
+            f"(timing_prior={timing_prior}, prior_scale={prior_scale}, "
+            f"use_parallel={use_parallel})..."
         )
         KF = jax_kalman_filter.JaxKalmanFilter(
             data=pulsar_data,
             use_gw=use_gw,
             timing_prior=timing_prior,
             prior_scale=prior_scale,
+            use_parallel=use_parallel,
         )
 
     return pulsar_data, KF

--- a/test/test_jax_kalman_filter.py
+++ b/test/test_jax_kalman_filter.py
@@ -2,6 +2,7 @@
 
 import pytest
 import numpy as np
+import jax
 import jax.numpy as jnp
 from unittest.mock import Mock, patch
 from argus import jax_kalman_filter, bayesian_inference
@@ -634,3 +635,206 @@ class TestDiffuseFilter:
         assert np.isclose(
             ll_filter, ll_batch, rtol=1e-5, atol=1e-3
         ), f"filter {ll_filter} != batch GLS {ll_batch}"
+
+
+def _reference_sequential_filter(m0, P0, Fs, Qs, Hs, Rs, zs):
+    """Independent textbook linear-Gaussian Kalman filter for tests.
+
+    Matches the Argus epoch convention: epoch 0 is update-only against the prior
+    (m0, P0); epochs 1..T-1 predict with (Fs[k-1], Qs[k-1]) then update. Uses the
+    standard-form covariance update (I - K H) P to match the square-root element
+    covariance factor. Returns stacked filtered means (T, d, 1) and covs (T, d, d).
+    """
+    d = m0.shape[0]
+    Id = jnp.eye(d)
+
+    def update(mp, Pp, H, R, z):
+        S = H @ Pp @ H.T + R
+        K = Pp @ H.T @ jnp.linalg.solve(S, jnp.eye(S.shape[0]))
+        m = mp + K @ (z[:, None] - H @ mp)
+        P = (Id - K @ H) @ Pp
+        return m, 0.5 * (P + P.T)
+
+    m, P = update(m0, P0, Hs[0], Rs[0], zs[0])
+    means, covs = [m], [P]
+    for k in range(1, len(zs)):
+        mp = Fs[k - 1] @ m
+        Pp = Fs[k - 1] @ P @ Fs[k - 1].T + Qs[k - 1]
+        m, P = update(mp, Pp, Hs[k], Rs[k], zs[k])
+        means.append(m)
+        covs.append(P)
+    return jnp.stack(means), jnp.stack(covs)
+
+
+class TestSqrtParallelFilter:
+    """Tests for the square-root temporally-parallel (associative-scan) filter.
+
+    The parked standard-form associative scan returned -inf on the real MDC2
+    array (catastrophic cancellation in `(I + C_i J_j)⁻¹` under the 1e-40 dynamic
+    range). The square-root reformulation carries Cholesky factors and combines
+    via QR, so the filtered covariance is PSD by construction. These tests cover
+    operator associativity, agreement with a sequential filter (well- and
+    ill-conditioned), PSD preservation, and end-to-end likelihood equivalence.
+    """
+
+    def _random_system(self, seed=0, d=4, m=2, T=6):
+        """Small well-conditioned linear-Gaussian system."""
+        rng = np.random.default_rng(seed)
+        m0 = jnp.array(rng.standard_normal((d, 1)))
+        A = rng.standard_normal((d, d))
+        P0 = jnp.array(A @ A.T + d * np.eye(d))
+        Fs = jnp.array(
+            [0.9 * np.eye(d) + 0.05 * rng.standard_normal((d, d)) for _ in range(T - 1)]
+        )
+        Qs = jnp.array(
+            [
+                (lambda B: B @ B.T + 0.1 * np.eye(d))(rng.standard_normal((d, d)))
+                for _ in range(T - 1)
+            ]
+        )
+        Hs = jnp.array([rng.standard_normal((m, d)) for _ in range(T)])
+        Rs = jnp.array(
+            [
+                (lambda B: B @ B.T + 0.5 * np.eye(m))(rng.standard_normal((m, m)))
+                for _ in range(T)
+            ]
+        )
+        zs = jnp.array(rng.standard_normal((T, m)))
+        return m0, P0, Fs, Qs, Hs, Rs, zs
+
+    def _sqrt_scan(self, m0, P0, Fs, Qs, Hs, Rs, zs):
+        """Build square-root elements from covariances and run the parallel scan."""
+        L_P0 = jnp.linalg.cholesky(P0)
+        L_Qs = jax.vmap(jnp.linalg.cholesky)(Qs)
+        L_Rs = jax.vmap(jnp.linalg.cholesky)(Rs)
+        b_filt, U_filt = jax_kalman_filter._sqrt_parallel_filter(
+            m0, L_P0, Fs, L_Qs, Hs, L_Rs, zs
+        )
+        C_filt = jnp.matmul(U_filt, jnp.swapaxes(U_filt, -1, -2))
+        return b_filt, C_filt
+
+    def test_operator_associativity(self):
+        """(e1 ⊗ e2) ⊗ e3 == e1 ⊗ (e2 ⊗ e3) for the square-root operator."""
+        _, _, Fs, Qs, Hs, Rs, zs = self._random_system(seed=1, T=4)
+        L_Qs = jax.vmap(jnp.linalg.cholesky)(Qs)
+        L_Rs = jax.vmap(jnp.linalg.cholesky)(Rs)
+        e1, e2, e3 = (
+            jax_kalman_filter._sqrt_generic_filtering_element(
+                Fs[k], L_Qs[k], Hs[k + 1], L_Rs[k + 1], zs[k + 1]
+            )
+            for k in range(3)
+        )
+        op = jax_kalman_filter._sqrt_filtering_operator
+        left = op(op(e1, e2), e3)
+        right = op(e1, op(e2, e3))
+
+        # A, b, eta, J compared directly; C = U Uᵀ compared reconstructed (the
+        # triangular covariance factor U itself is not unique).
+        for idx in (0, 1, 3, 4):  # A, b, eta, J
+            assert jnp.allclose(left[idx], right[idx], atol=1e-8, rtol=1e-6)
+        CL, CR = left[2] @ left[2].T, right[2] @ right[2].T
+        assert jnp.allclose(CL, CR, atol=1e-8, rtol=1e-6)
+
+    def test_matches_sequential_small_system(self):
+        """Parallel filtered means/covs match a sequential filter (well-conditioned)."""
+        m0, P0, Fs, Qs, Hs, Rs, zs = self._random_system(seed=2)
+        b_filt, C_filt = self._sqrt_scan(m0, P0, Fs, Qs, Hs, Rs, zs)
+        m_ref, P_ref = _reference_sequential_filter(m0, P0, Fs, Qs, Hs, Rs, zs)
+        assert jnp.allclose(b_filt, m_ref, atol=1e-8, rtol=1e-6)
+        assert jnp.allclose(C_filt, P_ref, atol=1e-8, rtol=1e-6)
+
+    def test_psd_preservation_ill_conditioned(self):
+        """Filtered covariance stays PSD under a 1e-40 dynamic range (the MDC2 regime).
+
+        This is exactly the configuration on which the standard-form scan lost
+        positive-definiteness (min eig ~ -59) and returned -inf.
+        """
+        m0, P0, Fs, Qs, Hs, Rs, zs = self._random_system(seed=3, d=4, m=2, T=8)
+        # Crush two state directions' prior/process variances to 1e-40 scale.
+        scale = jnp.array([1.0, 1e-40, 1.0, 1e-40])
+        D = jnp.diag(scale)
+        P0 = D @ P0 @ D
+        Qs = jnp.array([D @ Q @ D for Q in Qs])
+        _, C_filt = self._sqrt_scan(m0, P0, Fs, Qs, Hs, Rs, zs)
+        for k in range(C_filt.shape[0]):
+            C = 0.5 * (C_filt[k] + C_filt[k].T)
+            eig = jnp.linalg.eigvalsh(C)
+            rel = eig[0] / jnp.maximum(eig[-1], 1e-300)
+            assert rel > -1e-10, f"epoch {k}: min/max eig = {rel}"
+
+    @patch("argus.io_manager.get_argus_logger")
+    def test_matches_marginal_backend(self, mock_logger):
+        """Parallel backend must reproduce the sequential marginal log likelihood."""
+        mock_logger.return_value = Mock()
+        data = _realistic_pulsar_data()
+        params = TestMarginalFilter()._params()
+
+        kf_seq = jax_kalman_filter.JaxKalmanFilter(data=data, use_marginal=True)
+        kf_par = jax_kalman_filter.JaxKalmanFilter(
+            data=data, use_marginal=True, use_parallel=True
+        )
+        ll_seq = kf_seq.get_likelihood(params)
+        ll_par = kf_par.get_likelihood(params)
+
+        assert ll_par.shape == ()
+        assert jnp.isfinite(ll_par)
+        assert jnp.isclose(
+            ll_par, ll_seq, rtol=1e-6, atol=1e-4
+        ), f"parallel {ll_par} != sequential {ll_seq}"
+
+    @patch("argus.io_manager.get_argus_logger")
+    def test_diffuse_matches_marginal_backend(self, mock_logger):
+        """Parallel backend must also match the sequential diffuse marginal likelihood."""
+        mock_logger.return_value = Mock()
+        data = _realistic_pulsar_data()
+        params = TestMarginalFilter()._params()
+
+        kf_seq = jax_kalman_filter.JaxKalmanFilter(
+            data=data, use_marginal=True, timing_prior="diffuse"
+        )
+        kf_par = jax_kalman_filter.JaxKalmanFilter(
+            data=data, use_marginal=True, timing_prior="diffuse", use_parallel=True
+        )
+        ll_seq = kf_seq.get_likelihood(params)
+        ll_par = kf_par.get_likelihood(params)
+        assert jnp.isclose(
+            ll_par, ll_seq, rtol=1e-6, atol=1e-4
+        ), f"parallel diffuse {ll_par} != sequential {ll_seq}"
+
+    @patch("argus.io_manager.get_argus_logger")
+    def test_gradients_finite_and_match(self, mock_logger):
+        """Gradients must flow through the parallel filter and match the sequential ones.
+
+        NUTS differentiates the likelihood, so finite gradients are required. The
+        information-matrix square-root form (zero-padded Z) produced NaN gradients
+        via QR reverse-mode; carrying J as a plain matrix fixes this.
+        """
+        mock_logger.return_value = Mock()
+        data = _realistic_pulsar_data()
+        base = TestMarginalFilter()._params()
+
+        def grad_dlog10_ha(use_parallel):
+            kf = jax_kalman_filter.JaxKalmanFilter(
+                data=data, use_marginal=True, use_parallel=use_parallel
+            )
+
+            def f(log10_ha):
+                p = base.replace(ha=10.0**log10_ha)
+                return kf.get_likelihood(p)
+
+            return jax.grad(f)(jnp.log10(base.ha))
+
+        g_seq = grad_dlog10_ha(False)
+        g_par = grad_dlog10_ha(True)
+        assert jnp.isfinite(g_par), f"parallel gradient not finite: {g_par}"
+        assert jnp.isclose(g_par, g_seq, rtol=1e-4, atol=1e-4), f"{g_par} != {g_seq}"
+
+    @patch("argus.io_manager.get_argus_logger")
+    def test_requires_marginal(self, mock_logger):
+        """use_parallel=True is only supported on the marginal backend."""
+        mock_logger.return_value = Mock()
+        data = _realistic_pulsar_data()
+        with pytest.raises(ValueError, match="marginal"):
+            jax_kalman_filter.JaxKalmanFilter(
+                data=data, use_marginal=False, use_parallel=True
+            )

--- a/test/test_likelihood_value.py
+++ b/test/test_likelihood_value.py
@@ -101,6 +101,18 @@ def test_likelihood_value():
             abs(log_likelihood - expected_likelihood) < 1.0
         ), f"[{backend}] Expected ~{expected_likelihood}, got {log_likelihood}"
 
+    # The temporally-parallel square-root (associative-scan) backend must also
+    # reproduce the golden value: it is the same marginal likelihood computed in
+    # O(log T) depth instead of an O(T) sequential scan.
+    KF_par = jk.JaxKalmanFilter(
+        data=pulsar_data, use_gw=True, use_marginal=True, use_parallel=True
+    )
+    ll_parallel = KF_par.get_likelihood(params)
+    print("the computed log likelihood (parallel) is:", ll_parallel)
+    assert (
+        abs(ll_parallel - expected_likelihood) < 1.0
+    ), f"[parallel] Expected ~{expected_likelihood}, got {ll_parallel}"
+
     # Diffuse (flat/improper) timing-model prior on the marginal filter. This is a
     # different likelihood from the informative-prior golden above (P_eps⁻¹ → 0 fully
     # projects out the timing-model subspace and drops a parameter-independent additive
@@ -116,3 +128,17 @@ def test_likelihood_value():
     assert (
         abs(log_likelihood_diffuse - expected_diffuse_likelihood) < 1.0
     ), f"[diffuse] Expected ~{expected_diffuse_likelihood}, got {log_likelihood_diffuse}"
+
+    # Parallel backend on the diffuse prior must also reproduce the diffuse golden.
+    KF_diffuse_par = jk.JaxKalmanFilter(
+        data=pulsar_data,
+        use_gw=True,
+        use_marginal=True,
+        timing_prior="diffuse",
+        use_parallel=True,
+    )
+    ll_diffuse_par = KF_diffuse_par.get_likelihood(params)
+    print("the computed log likelihood (diffuse, parallel) is:", ll_diffuse_par)
+    assert (
+        abs(ll_diffuse_par - expected_diffuse_likelihood) < 1.0
+    ), f"[diffuse-parallel] Expected ~{expected_diffuse_likelihood}, got {ll_diffuse_par}"


### PR DESCRIPTION
## Issue #103 PR1 — temporal parallelization via associative scan (square-root, numerically stable)

Numerically-stable, **NUTS-ready** replacement for the parked standard-form
associative-scan filter. Targets the default marginal backend behind an opt-in
`use_parallel` flag (default `False`; the production path is unchanged).

**Draft** — the implementation is correct and merge-bar-clean (golden-preserving,
PSD-stable, finite gradients), but the speed payoff does **not** materialize at
MDC2 scale (see Benchmarks). Opening for review of the approach; not proposing to
flip any default.

### Relationship to other work on #103
- Closes the PR1 strand of **#103** (Kalman-filter performance).
- **Supersedes #104** (the parked standard-form associative scan, which returned
  `-inf` on the MDC2 array). #104 can be closed once this is reviewed.
- Builds on the merged **PR2 / #107** (marginalized + diffuse timing-model filter):
  this parallelizes that default marginal recursion.
- Mirrors the near-singular-covariance jitter/PD policy from **#102** in the
  recomputed innovation covariance.

### Why a square-root filter
#104's standard-form combination `(I + C_i J_j)⁻¹` suffered catastrophic
cancellation under the array's extreme dynamic range (position-state prior
variance `1e-40`, smallest innovation-cov eigenvalue `~8e-14`): the filtered
covariance lost positive-definiteness within a few epochs and the likelihood
collapsed to `-inf`.

This PR carries the **covariance** block as a Cholesky factor `C = U Uᵀ` (the block
that must stay PSD) and combines via QR, so the filtered covariance is PSD by
construction. The operator is derived from Särkkä & García-Fernández (2021) via the
Woodbury identity

```
(I + C_i J_j)⁻¹ C_i = U_i M⁻¹ U_iᵀ,   M = I + U_iᵀ J_j U_i   (PD, ⪰ I)
```

so the only inverse is a Cholesky solve against `M` (perfectly conditioned
regardless of the `1e-40` scaling) and the only QR is on a full-rank stack
`[A_j U_i M⁻ᵀᐟ² | U_j]`.

### The gradient fix (NUTS-readiness)
NUTS differentiates the likelihood. A first cut carried the **information** block in
square-root factor form (`Z`, zero-padded to a fixed shape for the scan) — but JAX's
QR reverse-mode divides by zero on the rank-deficient pre-arrays, giving **NaN
gradients** (forward pass was fine). Fix: keep the information block `J` as a **plain
matrix**. It only ever enters through `M = I + Uᵀ J U ⪰ I`, whose conditioning is
immune to `J` being ill-scaled, so every QR here is full-rank and gradients flow.

### What's implemented
All in `python/argus/jax_kalman_filter.py`:
- `_tria`, `_chol_psd`, `_sqrt_first_filtering_element`,
  `_sqrt_generic_filtering_element`, `_sqrt_filtering_operator`,
  `_sqrt_parallel_filter`, `_run_sqrt_dynamic_filter` (a dynamic-state-only entry
  point), `_affine_compose`, and `_run_kalman_filter_marginal_parallel` (identical
  signature to `_run_kalman_filter_marginal`).
- The marginal recursion is parallelized as: (1) a square-root associative scan over
  the `4·Npsr` dynamic state → filtered mean + covariance factor; (2) a second
  (affine) associative scan for the timing-model sensitivity `Ξ = ∂x/∂β`; (3)
  additive reductions for the `A,b,c,L` epsilon information; final β-marginalization
  identical to the sequential filter.
- Opt-in `use_parallel` flag on `JaxKalmanFilter` (requires `use_marginal=True`;
  supports both `timing_prior` modes), dispatched in `get_likelihood`, plus a
  `use_parallel` config key in `workflow.py [PriorModel]`.

### Correctness
| Prior | golden | parallel logL | Δ | gradient |
|---|---|---|---|---|
| informative | 63618.93 | 63618.7968 | −0.13 | finite, matches sequential |
| diffuse | 59420.06 | 59420.0598 | −0.0002 | finite, matches sequential |

Filtered covariance stays PSD to roundoff (`min eig/max eig ≈ −6e-16`) on the real
MDC2 array, vs `min eig ≈ −59` for #104.

### Benchmarks (honest)
The associative scan is a **reordering of the same arithmetic** — identical logL and
gradients — so it does **not** change the likelihood surface / NUTS geometry; only
per-step wall-clock. Warm-jit on A100 (A100-SXM4-80GB), MDC2 (T=183, Npsr=32):

| path | sequential | parallel | ratio |
|---|---|---|---|
| forward `logL` | 59 ms | 269 ms | **0.22× (4.5× slower)** |
| `value_and_grad` (NUTS hot path) | 147 ms | 355 ms | **0.41× (2.4× slower)** |

GPU utilisation was ~12.5% — the problem is too small to saturate the A100, so it is
latency/overhead-bound and the `O(log T=7.6)` vs `O(T=183)` depth advantage is
swamped by the per-element QR/Cholesky cost + the Ξ scan. The gradient path narrows
the gap (the parallel backward sweep parallelises), consistent with a crossover at
much larger `T`. A full NUTS run would sample identically at ~2.4× the wall-clock, so
it would not reveal a hidden benefit. Value is expected only at large `T`
(long-baseline / online inference).

### Test plan
- `test/test_jax_kalman_filter.py::TestSqrtParallelFilter` — operator associativity,
  PSD preservation under a `1e-40` dynamic range, match-to-sequential (well- and
  ill-conditioned), backend equivalence, gradient finiteness, and `use_marginal`
  validation.
- `test/test_likelihood_value.py` — parallel informative/diffuse golden cases.
- Full suite: 249 passed, 1 skipped; `ruff` + `black` clean.

### Open question for reviewers
Worth a `value_and_grad` T-scaling study (synthetic, vary #epochs) to locate the
crossover where the parallel filter wins — the number that would justify it for
long-baseline / online use — before deciding whether this stays opt-in groundwork or
becomes a default in a specific regime.
