### PR TITLE
docs: nested-sampling reference record (from #106, parked)

### DIFF
--- a/python/argus/bayesian_inference.py
+++ b/python/argus/bayesian_inference.py
@@ -1021,7 +1021,9 @@ def _blackjax_ns_evidence(
     n_steps = 0
     t_start = time.perf_counter()
     t_compiled = None
-    prev_progress = None  # (step, gap, wall) at the last progress print, for the ETA estimate
+    prev_progress = (
+        None  # (step, gap, wall) at the last progress print, for the ETA estimate
+    )
     for i in range(max_steps):
         rng_key, subkey = jax.random.split(rng_key)
         state, info = step(subkey, state)
@@ -1068,9 +1070,7 @@ def _blackjax_ns_evidence(
 
     dead_info = ns_utils.finalise(state, dead)
     # Point estimate: accumulated dead-point evidence + remaining live contribution.
-    logZ_point = float(
-        jnp.logaddexp(state.integrator.logZ, state.integrator.logZ_live)
-    )
+    logZ_point = float(jnp.logaddexp(state.integrator.logZ, state.integrator.logZ_live))
     # Uncertainty: stochastic-volume realisations of the evidence (Skilling 2006).
     rng_key, subkey = jax.random.split(rng_key)
     log_w = ns_utils.log_weights(subkey, dead_info, shape=weights_shape)
@@ -1172,17 +1172,15 @@ def run_blackjax_nested_sampling(
     sizes = [int(np.prod(s)) if s else 1 for s in shapes]
     ndim = int(sum(sizes))
     det_names = [
-        name
-        for name, site in disc_trace.items()
-        if site["type"] == "deterministic"
+        name for name, site in disc_trace.items() if site["type"] == "deterministic"
     ]
 
     def unpack(z):
         out = {}
         offset = 0
         for name, shape, size in zip(names, shapes, sizes):
-            out[name] = z[offset] if shape == () else z[offset : offset + size].reshape(
-                shape
+            out[name] = (
+                z[offset] if shape == () else z[offset : offset + size].reshape(shape)
             )
             offset += size
         return out
@@ -1297,8 +1295,7 @@ def run_blackjax_nested_sampling(
     physical = jax.lax.map(to_physical, post_z)
     # ArviZ expects (chains, draws, ...); single chain for nested sampling.
     posterior_np = {
-        name: np.asarray(values)[np.newaxis, ...]
-        for name, values in physical.items()
+        name: np.asarray(values)[np.newaxis, ...] for name, values in physical.items()
     }
     inf_data = az.from_dict(posterior=posterior_np)
 

--- a/python/argus/bayesian_inference.py
+++ b/python/argus/bayesian_inference.py
@@ -917,6 +917,394 @@ def run_nested_sampling(
     return inf_data, (log_Z_mean, log_Z_uncert)
 
 
+def _import_blackjax_ns():
+    """Import blackjax with its nested-sampling module, shimming ``jax.shard_map``.
+
+    The blackjax nested sampler (``blackjax.nss`` + ``blackjax.ns``) lives in the
+    blackjax-devs ``main`` source (>=1.6.dev), not the PyPI wheels. Its package
+    ``__init__`` eagerly imports ``blackjax.eca``, which does ``from jax import
+    shard_map`` — promoted to the top-level ``jax`` namespace only in jax>=0.5. On
+    Argus's pinned jax 0.4.38 we alias it from ``jax.experimental.shard_map`` so
+    ``import blackjax`` succeeds. The NS module itself uses only long-stable jax APIs
+    and runs correctly on 0.4.38 (validated against analytic logZ; see
+    ``workflows/ng15_sgwb_demo/notes/t2.6_blackjax_ns_verdict.md``).
+    """
+    if not hasattr(jax, "shard_map"):
+        try:
+            from jax.experimental.shard_map import shard_map as _shard_map
+
+            jax.shard_map = _shard_map
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ImportError(
+                "Could not shim jax.shard_map for blackjax on this jax version."
+            ) from exc
+    import blackjax
+
+    if not hasattr(blackjax, "nss"):
+        raise ImportError(
+            "Installed blackjax has no nested sampler (blackjax.nss). Install the "
+            "blackjax-devs main source without touching the pinned jax:\n"
+            "  pip install --no-deps "
+            "'git+https://github.com/blackjax-devs/blackjax@main'"
+        )
+    return blackjax
+
+
+def _blackjax_ns_evidence(
+    logprior_fn,
+    loglikelihood_fn,
+    init_particles,
+    *,
+    num_delete=1,
+    num_inner_steps=None,
+    dlogz=-5.0,
+    max_steps=100000,
+    rng_key=None,
+    weights_shape=200,
+    progress_every=0,
+    kernel="nss",
+):
+    """Run blackjax nested slice sampling and return the evidence + dead points.
+
+    ``kernel`` selects the inner MCMC kernel: ``"nss"`` (default) is the monolithic
+    hit-and-run slice sampler; ``"nsswig"`` is the axis-aligned slice-within-Gibbs
+    kernel of Yallup (2026, arXiv:2602.17414), which exploits hierarchical structure
+    by sweeping coordinates rather than treating the parameter vector as one block.
+    Both consume the same black-box ``logprior_fn``/``loglikelihood_fn`` and the same
+    ``num_delete``/``num_inner_steps`` knobs, so they are directly comparable.
+
+    This is the engine core shared by :func:`run_blackjax_nested_sampling` (GWB on real
+    data) and the analytic-Gaussian validation script, so the code path validated
+    against a known logZ is exactly the one used for inference.
+
+    Parameters
+    ----------
+    logprior_fn, loglikelihood_fn : callable
+        Functions of a flat latent vector ``z`` returning scalar log-prior and
+        log-likelihood. The prior is the sampling measure; the evidence is
+        ``Z = int L(z) prior(z) dz``.
+    init_particles : jnp.ndarray
+        Initial live points, shape ``(num_live, ndim)``, drawn from the prior.
+    num_delete, num_inner_steps, dlogz, max_steps, weights_shape : see config.
+    rng_key : jax.Array or None
+
+    Returns
+    -------
+    dict
+        ``logZ`` (point estimate = dead + remaining-live), ``logZ_stochastic_mean``
+        and ``logZ_err`` (mean/std over stochastic-volume realisations), ``logZ_live``,
+        ``n_steps``, ``dead_info`` (finalised), ``final_state``, ``rng_key``, ``blackjax``.
+    """
+    blackjax = _import_blackjax_ns()
+    from blackjax.ns import utils as ns_utils
+    from jax.scipy.special import logsumexp
+
+    n_live, ndim = init_particles.shape
+    if num_inner_steps is None:
+        num_inner_steps = max(5, 2 * ndim)
+    if rng_key is None:
+        rng_key = jax.random.PRNGKey(0)
+
+    if kernel not in ("nss", "nsswig"):
+        raise ValueError(f"kernel must be 'nss' or 'nsswig', got {kernel!r}")
+    ns_constructor = getattr(blackjax, kernel)
+    algo = ns_constructor(
+        logprior_fn=logprior_fn,
+        loglikelihood_fn=loglikelihood_fn,
+        num_delete=num_delete,
+        num_inner_steps=num_inner_steps,
+    )
+    state = algo.init(init_particles)
+    step = jax.jit(algo.step)
+
+    dead = []
+    n_steps = 0
+    t_start = time.perf_counter()
+    t_compiled = None
+    prev_progress = None  # (step, gap, wall) at the last progress print, for the ETA estimate
+    for i in range(max_steps):
+        rng_key, subkey = jax.random.split(rng_key)
+        state, info = step(subkey, state)
+        dead.append(info)
+        n_steps = i + 1
+        # Delta between accumulated dead evidence and the live remainder; drives termination.
+        gap = float(state.integrator.logZ_live - state.integrator.logZ)
+        if i == 0:
+            # First step includes JIT compilation; separate it from steady-state cost.
+            t_compiled = time.perf_counter()
+            if progress_every:
+                print(
+                    f"    [NS] compiled step in {t_compiled - t_start:.1f}s",
+                    flush=True,
+                )
+        if progress_every and (i % progress_every == 0):
+            now = time.perf_counter()
+            # ETA: the gap (logZ_live - logZ) trends down toward the `dlogz` termination
+            # threshold. It is NOT monotonic (jumps up when a new high-L region is found), so
+            # estimate remaining steps from the recent average descent rate and guard against
+            # non-negative slopes. Rough by design — a "how much is left" gauge, not a promise.
+            eta_str = ""
+            if prev_progress is not None:
+                di = i - prev_progress[0]
+                dgap = gap - prev_progress[1]  # negative when descending
+                if di > 0 and dgap < 0:
+                    steps_left = max(0.0, (gap - dlogz) / (-dgap / di))
+                    sec_per_step = (now - prev_progress[2]) / di
+                    eta_s = steps_left * sec_per_step
+                    eta_str = f"  ETA~{eta_s/3600:5.2f}h (~{steps_left:.0f} steps)"
+                else:
+                    eta_str = "  ETA~(gap rose)"
+            prev_progress = (i, gap, now)
+            print(
+                f"    [NS] step {i:6d}  logZ={float(state.integrator.logZ):10.3f}  "
+                f"logZ_live-logZ={gap:8.3f}  elapsed={now - t_start:7.1f}s{eta_str}",
+                flush=True,
+            )
+        # Terminate once the evidence still held in the live points is a negligible
+        # fraction of what has been accumulated from the dead points. The i>1 guard only
+        # skips the initial transient (logZ starts at -inf, so gap is +inf on step 0).
+        if i > 1 and gap < dlogz:
+            break
+
+    dead_info = ns_utils.finalise(state, dead)
+    # Point estimate: accumulated dead-point evidence + remaining live contribution.
+    logZ_point = float(
+        jnp.logaddexp(state.integrator.logZ, state.integrator.logZ_live)
+    )
+    # Uncertainty: stochastic-volume realisations of the evidence (Skilling 2006).
+    rng_key, subkey = jax.random.split(rng_key)
+    log_w = ns_utils.log_weights(subkey, dead_info, shape=weights_shape)
+    logZ_samples = logsumexp(log_w, axis=0)  # (weights_shape,)
+    return {
+        "logZ": logZ_point,
+        "logZ_stochastic_mean": float(jnp.mean(logZ_samples)),
+        "logZ_err": float(jnp.std(logZ_samples)),
+        "logZ_live": float(state.integrator.logZ_live),
+        "n_steps": n_steps,
+        "n_live": n_live,
+        "ndim": int(ndim),
+        "dead_info": dead_info,
+        "final_state": state,
+        "rng_key": rng_key,
+        "blackjax": blackjax,
+    }
+
+
+def run_blackjax_nested_sampling(
+    kalman_filter,
+    config,
+    n_pulsars,
+    sigma_p_array,
+    gamma_p_array,
+    efac_array,
+    equad_array,
+    mode="gwb",
+):
+    """Run blackjax nested sampling for GWB inference — a JAX-native evidence engine.
+
+    Computes the Bayesian evidence (logZ) for the GWB model with blackjax nested slice
+    sampling on Argus's differentiable Kalman likelihood, unlocking model-comparison
+    (HD-vs-CURN) Bayes factors that NUTS cannot provide. Introduced as the T2.6
+    feasibility spike; see ``workflows/ng15_sgwb_demo/notes/t2.6_blackjax_ns_verdict.md``.
+
+    The sampler works in the GWB model's **native reparameterized latent space**: every
+    free ``numpyro.sample`` site in :func:`numpyro_model` is ``Normal(0, 1)`` (the
+    physical parameters are ``deterministic`` transforms), so the prior is an isotropic
+    unit Gaussian — Jacobian-free — and the evidence/posterior are directly comparable to
+    the NUTS run on the same config. The likelihood is obtained by reusing numpyro's own
+    ``log_density`` on the exact same model (``loglik = log_joint - logprior``), so no
+    transform is re-implemented.
+
+    Parameters
+    ----------
+    kalman_filter : object
+        JAX Kalman filter with ``get_likelihood``.
+    config : configparser.ConfigParser
+    n_pulsars : int
+    sigma_p_array, gamma_p_array, efac_array, equad_array : arrays or None
+    mode : str
+        Only ``"gwb"`` is supported (CW uses the jaxns path in
+        :func:`run_nested_sampling`).
+
+    Returns
+    -------
+    tuple
+        ``(arviz.InferenceData, (logZ_mean, logZ_uncert), ns_meta)`` where ``ns_meta``
+        is a dict of additive cost-scaling metadata (``runtime_s``, ``n_steps``,
+        ``ndim``, ``n_live``, ``num_delete``, ``num_inner_steps``, ``n_pulsars``). The
+        first two elements match the return contract of :func:`run_nested_sampling`;
+        the third is blackjax-specific and consumed by :mod:`workflow`.
+    """
+    if mode != "gwb":
+        raise NotImplementedError(
+            "run_blackjax_nested_sampling supports mode='gwb'; use "
+            "run_nested_sampling (jaxns) for CW."
+        )
+    import numpy as np
+    from numpyro.handlers import trace, seed, substitute
+    from numpyro.infer.util import log_density
+    from .prior_models import get_prior_model_specs
+
+    prior_specs = get_prior_model_specs(
+        config,
+        n_pulsars,
+        sigma_p_array,
+        gamma_p_array,
+        efac_array,
+        equad_array,
+        mode="gwb",
+    )
+
+    def model():
+        numpyro_model(kalman_filter, prior_specs, n_pulsars)
+
+    # Discover the free latent sites (all N(0,1)) and the deterministic (physical) sites.
+    seed_val = config.getint("NestedSampler", "seed", fallback=42)
+    key = jax.random.PRNGKey(seed_val)
+    disc_trace = trace(seed(model, key)).get_trace()
+    latent = {
+        name: site
+        for name, site in disc_trace.items()
+        if site["type"] == "sample" and not site.get("is_observed", False)
+    }
+    names = list(latent.keys())
+    shapes = [tuple(jnp.shape(latent[name]["value"])) for name in names]
+    sizes = [int(np.prod(s)) if s else 1 for s in shapes]
+    ndim = int(sum(sizes))
+    det_names = [
+        name
+        for name, site in disc_trace.items()
+        if site["type"] == "deterministic"
+    ]
+
+    def unpack(z):
+        out = {}
+        offset = 0
+        for name, shape, size in zip(names, shapes, sizes):
+            out[name] = z[offset] if shape == () else z[offset : offset + size].reshape(
+                shape
+            )
+            offset += size
+        return out
+
+    half_log_2pi = 0.5 * jnp.log(2.0 * jnp.pi)
+    # Bound the (unit-normal) latent prior to a wide box so the slice sampler cannot step
+    # out into the extreme tails, where the Kalman likelihood is numerically pathological
+    # (near-singular innovation covariance -> spuriously huge log-likelihood). At the default
+    # 6 sigma the truncated N(0,1) mass loss is ~2e-9/dim, so the evidence is unchanged, but
+    # unlike gradient-guided NUTS (which stays in the typical set) NS explores globally and
+    # would otherwise get stuck on a spurious high-likelihood tail point.
+    latent_cutoff = config.getfloat("NestedSampler", "latent_cutoff", fallback=6.0)
+
+    def _unit_normal_logprior(z):
+        # The unbounded N(0,1) density — matches the prior log_density() accumulates
+        # internally from the model's Normal(0,1) sample sites, so subtracting it isolates
+        # the pure log-likelihood.
+        return -0.5 * jnp.sum(z**2) - ndim * half_log_2pi
+
+    def logprior_fn(z):
+        # Prior measure blackjax integrates: unit normal, truncated to the wide box.
+        inside = jnp.all(jnp.abs(z) <= latent_cutoff)
+        return jnp.where(inside, _unit_normal_logprior(z), -jnp.inf)
+
+    def loglikelihood_fn(z):
+        log_joint, _ = log_density(model, (), {}, unpack(z))
+        ll = log_joint - _unit_normal_logprior(z)
+        # Defensive: reject any residual non-finite likelihood inside the box.
+        return jnp.where(jnp.isfinite(ll), ll, -jnp.inf)
+
+    # Nested-sampler configuration.
+    num_live = config.getint("NestedSampler", "num_live_points", fallback=500)
+    num_delete = config.getint("NestedSampler", "num_delete", fallback=1)
+    num_inner_steps = config.getint(
+        "NestedSampler", "num_inner_steps", fallback=max(5, 2 * ndim)
+    )
+    dlogz = config.getfloat("NestedSampler", "dlogz", fallback=-5.0)
+    max_steps = config.getint("NestedSampler", "max_samples", fallback=100000)
+    weights_shape = config.getint("NestedSampler", "weights_shape", fallback=200)
+    progress_every = config.getint("NestedSampler", "progress_every", fallback=10)
+    num_posterior_samples = config.getint(
+        "NestedSampler", "num_posterior_samples", fallback=10000
+    )
+    kernel = config.get("NestedSampler", "kernel", fallback="nss").strip().lower()
+
+    key, subkey = jax.random.split(key)
+    init_particles = jax.random.normal(subkey, (num_live, ndim))
+
+    print("Running blackjax nested slice sampling (GWB)...")
+    print(f"  latent dimension: {ndim}")
+    print(f"  num_live_points: {num_live}")
+    print(f"  num_delete: {num_delete}")
+    print(f"  num_inner_steps: {num_inner_steps}")
+    print(f"  dlogz termination: {dlogz}")
+    print(f"  inner kernel: {kernel}")
+
+    key, subkey = jax.random.split(key)
+    t_sample_start = time.perf_counter()
+    res = _blackjax_ns_evidence(
+        logprior_fn,
+        loglikelihood_fn,
+        init_particles,
+        num_delete=num_delete,
+        num_inner_steps=num_inner_steps,
+        dlogz=dlogz,
+        max_steps=max_steps,
+        rng_key=subkey,
+        weights_shape=weights_shape,
+        progress_every=progress_every,
+        kernel=kernel,
+    )
+    sampling_runtime_s = time.perf_counter() - t_sample_start
+    log_Z_mean = res["logZ"]
+    log_Z_uncert = res["logZ_err"]
+    print(
+        f"\nLog-evidence: {log_Z_mean:.2f} +/- {log_Z_uncert:.2f} "
+        f"({res['n_steps']} steps, {sampling_runtime_s:.1f} s sampling)"
+    )
+
+    # Cost-scaling metadata (additive; does not affect the evidence/posterior). Consumed by
+    # workflow.py to enrich the evidence JSON and by the NS scaling study
+    # (workflows/ng15_sgwb_demo/scripts/ns_scaling_analyze.py).
+    ns_meta = {
+        "runtime_s": float(sampling_runtime_s),
+        "n_steps": int(res["n_steps"]),
+        "ndim": int(res["ndim"]),
+        "n_live": int(res["n_live"]),
+        "num_delete": int(num_delete),
+        "num_inner_steps": int(num_inner_steps),
+        "n_pulsars": int(n_pulsars),
+        "kernel": kernel,
+        "logZ_stochastic_mean": float(res["logZ_stochastic_mean"]),
+    }
+
+    # Posterior: resample the latent live points by weight, push through the model to
+    # recover the physical (deterministic) parameters, and package as ArviZ.
+    from blackjax.ns import utils as ns_utils
+
+    key, subkey = jax.random.split(res["rng_key"])
+    post_z = ns_utils.sample(
+        subkey, res["dead_info"], shape=num_posterior_samples
+    ).position  # (num_posterior_samples, ndim)
+
+    def to_physical(z):
+        tr = trace(substitute(model, unpack(z))).get_trace()
+        return {name: tr[name]["value"] for name in det_names}
+
+    # Sequential (lax.map), NOT vmap: tracing the model also runs the joint Kalman
+    # likelihood, whose per-sample intermediates are large; vmapping over thousands of
+    # posterior draws materialises all of them at once and OOMs the GPU (~100 GB for the
+    # 32-pulsar model). lax.map keeps memory at one draw's footprint.
+    physical = jax.lax.map(to_physical, post_z)
+    # ArviZ expects (chains, draws, ...); single chain for nested sampling.
+    posterior_np = {
+        name: np.asarray(values)[np.newaxis, ...]
+        for name, values in physical.items()
+    }
+    inf_data = az.from_dict(posterior=posterior_np)
+
+    return inf_data, (log_Z_mean, log_Z_uncert), ns_meta
+
+
 def test_likelihood_performance(kalman_filter, config, n_pulsars, logger):
     """Test likelihood evaluation performance using known parameter values.
 

--- a/python/argus/workflow.py
+++ b/python/argus/workflow.py
@@ -167,15 +167,17 @@ def run_inference(config_path, use_gw=True, timestamp=None):
 
     if sampler_method in ("blackjax", "blackjax_ns"):
         logger.info(f"Running blackjax nested sampling (mode={signal_model})...")
-        results, log_evidence, ns_meta = bayesian_inference.run_blackjax_nested_sampling(
-            KF,
-            config,
-            len(pulsar_data["metadata"]),
-            sigma_p_array,
-            gamma_p_array,
-            efac_array,
-            equad_array,
-            mode=signal_model,
+        results, log_evidence, ns_meta = (
+            bayesian_inference.run_blackjax_nested_sampling(
+                KF,
+                config,
+                len(pulsar_data["metadata"]),
+                sigma_p_array,
+                gamma_p_array,
+                efac_array,
+                equad_array,
+                mode=signal_model,
+            )
         )
         logger.info(
             f"Bayesian evidence: log_Z = {log_evidence[0]:.2f} +/- {log_evidence[1]:.2f}"

--- a/python/argus/workflow.py
+++ b/python/argus/workflow.py
@@ -163,8 +163,24 @@ def run_inference(config_path, use_gw=True, timestamp=None):
     # Select sampler and run inference
     sampler_method = config.get("Data", "sampler", fallback="nuts").strip().lower()
     log_evidence = None
+    ns_meta = None
 
-    if sampler_method in ("nested", "jaxns"):
+    if sampler_method in ("blackjax", "blackjax_ns"):
+        logger.info(f"Running blackjax nested sampling (mode={signal_model})...")
+        results, log_evidence, ns_meta = bayesian_inference.run_blackjax_nested_sampling(
+            KF,
+            config,
+            len(pulsar_data["metadata"]),
+            sigma_p_array,
+            gamma_p_array,
+            efac_array,
+            equad_array,
+            mode=signal_model,
+        )
+        logger.info(
+            f"Bayesian evidence: log_Z = {log_evidence[0]:.2f} +/- {log_evidence[1]:.2f}"
+        )
+    elif sampler_method in ("nested", "jaxns"):
         logger.info(f"Running jaxns nested sampling (mode={signal_model})...")
         results, log_evidence = bayesian_inference.run_nested_sampling(
             KF,
@@ -202,10 +218,16 @@ def run_inference(config_path, use_gw=True, timestamp=None):
         import json
 
         evidence_path = os.path.join(output_dir, f"{output_id}_evidence.json")
+        evidence_payload = {
+            "log_Z_mean": log_evidence[0],
+            "log_Z_uncert": log_evidence[1],
+        }
+        # Additive cost-scaling metadata from the blackjax NS engine (runtime_s, n_steps,
+        # ndim, n_live, num_delete, num_inner_steps, n_pulsars). None for jaxns.
+        if ns_meta is not None:
+            evidence_payload.update(ns_meta)
         with open(evidence_path, "w") as f:
-            json.dump(
-                {"log_Z_mean": log_evidence[0], "log_Z_uncert": log_evidence[1]}, f
-            )
+            json.dump(evidence_payload, f, indent=2)
         logger.info(f"Evidence saved to {evidence_path}")
 
     # Create plots and diagnostics

--- a/research-evaluations/2026-07-09-blackjax-nested-sampling-model-selection.md
+++ b/research-evaluations/2026-07-09-blackjax-nested-sampling-model-selection.md
@@ -1,0 +1,87 @@
+---
+date: 2026-07-09
+topic: blackjax-nested-sampling-model-selection
+verdict: PURSUE
+nugget: "A JAX-native (blackjax) nested sampler on Argus's already-differentiable Kalman likelihood turns the SGWB result from an amplitude-under-assumed-template demonstration into an HD-vs-CURN Bayes-factor detection — lifting RISK B, the milestone's scoping ceiling."
+workflow: A
+dimensions:
+  novelty: 4
+  impact: 5
+  timing: 5
+  feasibility: 3
+  competitive-landscape: 4
+  the-nugget: 5
+  narrative-potential: 5
+revisit-conditions: "n/a (PURSUE as a kill-gated spike, T2.6)"
+scooping-watch: "blackjax NS applications to PTA/GW evidence; JAX-native nested sampling papers (arXiv:2601.23252 and citing work); enterprise/PTArcade evidence pipelines adopting gradient-based samplers."
+---
+
+# Should we add JAX-native nested sampling (blackjax) to Argus for model-selection/detection?
+
+**Decision:** PURSUE — as a **kill-gated feasibility spike (T2.6)** that runs in parallel with
+Stage 3, NOT as a hard blocker on T3.1. Folded into `TASKS.md` (T2.6 + conditional T3.4 upgrade)
+and `PLAN.md` (RISK B, out-of-scope) on 2026-07-09.
+
+## Context
+
+Argus pivoted from nested sampling to NUTS to exploit fast JAX gradients; jaxns was weak and
+`bayesian_inference.py:805 run_nested_sampling` raises `NotImplementedError` for GWB. The primary
+milestone is SGWB detection in real NG15 wideband data. **RISK B** caps the deliverable: HD is
+fixed inside the covariance, NUTS gives no evidence, so the honest claim is only *"a common
+HD-correlated amplitude consistent with the published value"* — a demonstration, not a Bayes-factor
+HD-vs-CURN *detection*. blackjax now ships a native nested sampler (sampling-book; arXiv:2601.23252),
+and its composable Markov kernels (arXiv:2602.17414) are cited as a strength over monolithic samplers.
+
+## Phase 1 — Problem assessment
+
+The question — "can we produce a model-comparison detection statistic (evidence / Bayes factor),
+not just a parameter posterior?" — is real and central, not constructed. It is the standard PTA
+detection framing (NANOGrav's headline is an HD Bayes factor). Passes Hamming's test for this
+project: the inference engine is the load-bearing capability, and evidence is the gap.
+
+## Phase 2 — Landscape
+
+PTA evidence is conventionally computed with non-differentiable `enterprise` + MultiNest/dynesty.
+JAX-native NS is newly viable (blackjax, 2026). Nothing about Argus's likelihood blocks NS — it is
+a pure differentiable JAX function already driving NUTS. Timing is a genuine intersection: the tool
+matured right as we need it.
+
+## Phase 3 — Comparative advantage (the decisive factor)
+
+Three-way intersection: (1) a **differentiable JAX-native PTA likelihood already built** — most PTA
+NS is non-differentiable, so gradient-augmented NS here is under-explored; (2) **prior NS experience**
+(dynesty, a recurring need in this group, not a one-off); (3) **timing** — early on the
+differentiable-likelihood + native-JAX-NS combination. This is comparative advantage, not effort.
+
+## Phase 4 — Risk assessment / de-risking
+
+Riskiest assumption: **does blackjax NS give trustworthy, reproducible evidence at acceptable cost?**
+Sub-risks: (a) evidence is prior-sensitive and our priors are reparameterized `U→N(0,1)` — Jacobians
+must be right or Z is silently wrong; (b) blackjax NS is new/less battle-tested; (c) ~15–20D
+hierarchical scaling cost. Cheapest test = validate Z on an analytic Gaussian (known Z), then the
+OU-injected synthetic (correctly-specified; cross-check vs the existing NUTS posterior), benchmark
+cost. Graceful exit: if it fails, keep NUTS + documented RISK-B framing, record why.
+
+## Phase 5 — Impact
+
+HIGH and portfolio-leveraged. Lifts the deliverable ceiling (RISK B) from demonstration to
+detection; the evidence engine is reusable for CW detection and the common-red-noise gap. Draft
+abstract test passes cleanly (topic: PTA SGWB; problem: NUTS gives no evidence; result: JAX-native
+NS yields an HD-vs-CURN Bayes factor on Argus; method: blackjax NS on the differentiable Kalman
+likelihood; significance: model-comparison detection, reusable across GW inference).
+
+Honesty flag: a *decisive* HD factor likely needs the full array (T3.5); on the 6-pulsar subset the
+spike proves the method and yields a weak factor / upper limit.
+
+## Phase 6 — Decision
+
+PURSUE as T2.6 (kill-gated spike, parallel to Stage 3). Do NOT block T3.1 — the real-data NUTS
+amplitude result proceeds regardless; the spike decides whether Stage 3's T3.4 produces a Bayes
+factor (pass) or the weaker amplitude contrast (fallback). Composable-kernel work (possible cure for
+the h_a↔γ_a ridge pathology found in T2.4) is a noted lower-priority follow-on, not scoped now.
+
+## Integration point
+
+Behind the config's existing `sampler` field; implement the `run_nested_sampling` GWB stub
+(`bayesian_inference.py:805`) with a blackjax-NS backend reusing the existing JAX likelihood. Check
+jax/blackjax version compatibility (Argus env pins jax 0.4.38).

--- a/workflows/ng15_sgwb_demo/configs/mdc2_blackjax_ns.ini
+++ b/workflows/ng15_sgwb_demo/configs/mdc2_blackjax_ns.ini
@@ -1,0 +1,81 @@
+# MDC2 GWB blackjax nested-sampling validation config (workflow task T2.6, GATE 3).
+#
+# Runs the blackjax nested sampler (sampler = blackjax) on the known-good idealized MDC2
+# dataset_2b, the same data the NUTS baseline (outputs/mdc2_smoke_wide/) was fit on. The
+# NS evidence engine is validated by cross-checking its posterior against that NUTS run:
+#   NUTS baseline recovers  log10_ha ~ -12.88 +/- 0.05,  log10_gamma_a ~ -8.1 +/- 0.13.
+# A trustworthy NS backend must reproduce those marginals AND give a reproducible logZ
+# across seeds. Red noise + white noise are FIXED (as in mdc2_smoke_lite.ini), so only the
+# two GW parameters are sampled -> a clean, cheap 2-D evidence check on the GPU (its natural
+# venue; the joint Kalman likelihood is slow on CPU).
+#
+# This is a clone of mdc2_smoke_lite.ini with [Data] sampler=blackjax + a [NestedSampler]
+# section. Runs on A100 via slurm_scripts/blackjax_ns_run.sh.
+
+[Data]
+sampler = blackjax
+data_path = /home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/data/IPTA_MockDataChallenge2/dataset_2b/
+excluded_psrs = J1640+2224
+
+[NestedSampler]
+# Nested-slice-sampling controls (see bayesian_inference.run_blackjax_nested_sampling).
+# num_delete >> 1 is the key speed knob: it batch-deletes the lowest-likelihood live points
+# each step, cutting the number of (sequential, Python-loop) NS steps by ~num_delete. Batch
+# deletion is evidence-consistent (Fowlie, Handley & Su 2021, via compute_num_live). At
+# num_delete=1 a 2-D run took >8000 steps (~2 h on A100); num_delete=25 finishes in minutes.
+num_live_points = 500
+num_delete = 25
+num_inner_steps = 5
+dlogz = -5.0
+max_samples = 60000
+num_posterior_samples = 2000
+weights_shape = 200
+seed = 42
+
+[PriorModel]
+
+# 1. GW background parameters (same wide, re-centred ranges as the NUTS smoke).
+log10_ha_fixed = false
+log10_ha_value = -12.5
+log10_ha_min = -16.0
+log10_ha_max = -9.0
+
+log10_gamma_a_fixed = false
+log10_gamma_a_value = -8.5
+log10_gamma_a_min = -11.0
+log10_gamma_a_max = -6.0
+
+# 2. Pulsar red noise parameters (FIXED via injections pickle -> not sampled).
+spin_injections_path = /home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/example_workflow_lite/data_files/approximate_spin_injections.pkl
+
+log10_gamma_p_min = -10.0
+log10_gamma_p_max = -7.0
+log10_sigma_p_min = -18.0
+log10_sigma_p_max = -14.0
+
+log10_gamma_p_mean_min = -9.0
+log10_gamma_p_mean_max = -7.0
+log10_gamma_p_std_min = 0.1
+log10_gamma_p_std_max = 1.0
+
+log10_ratio_mean_min = -8.0
+log10_ratio_mean_max = -4.0
+log10_ratio_std_min = 0.5
+log10_ratio_std_max = 3.0
+
+# 3. EFAC/EQUAD parameters (FIXED via noise JSON -> not sampled).
+noise_params_path = /home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/data/IPTA_MockDataChallenge2/group1_psr_noise.json
+
+efac_min = 0.5
+efac_max = 2.0
+log10_equad_min = -8.0
+log10_equad_max = -6.0
+
+[Logging]
+level = INFO
+enable_file_logging = false
+
+[Output]
+output_dir = /home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/ng15_sgwb_demo/outputs/
+output_id = mdc2_blackjax_ns
+base_dir = {output_id}

--- a/workflows/ng15_sgwb_demo/notes/DECISION_nested_sampling_parked.md
+++ b/workflows/ng15_sgwb_demo/notes/DECISION_nested_sampling_parked.md
@@ -1,0 +1,73 @@
+# DECISION: park nested sampling; use NUTS for inference (2026-07-10)
+
+**Status: DECIDED.** Slice-based nested sampling (NS) is **parked** as the evidence engine for
+Argus at PTA scale. Proceed with **NUTS** for posterior inference. Do **not** re-investigate
+slice-NS scaling without a new idea (see "Revisit only if" below).
+
+## Context
+
+T2.6 built a blackjax nested-slice-sampling (`blackjax.nss`) GWB evidence engine
+(`run_blackjax_nested_sampling`) to unlock **Bayesian evidence / logZ → HD-vs-CURN Bayes
+factors** (task T3.4), because NUTS gives a posterior but **no evidence**. This session (the
+"NS cost-scaling study") assessed whether NS is viable for a full PTA analysis. The answer is no.
+
+## What we found
+
+1. **Sampler dimensional scaling is benign.** On a likelihood-free analytic target, NS step
+   count grows only ~linearly with dimension (`n_steps ~ D^0.77`). Not the problem.
+2. **High-D evidence accuracy is tunable, not fundamental.** The default `num_inner_steps = 2D`
+   biases logZ for D≳10 (confirmed by our diagnostic *and* blackjax's own docstring); `~6D`
+   inner steps restores accuracy (held to D=120). A tuning cost, not a wall.
+3. **A numerical-robustness gap was exposed — and fixed.** NS's global prior exploration drives
+   the Kalman innovation covariance near-singular in the tails (triggered by high-precision
+   pulsars, e.g. J0437-4715), giving spurious huge log-likelihoods that NS locks onto. Fixed in
+   `_log_likelihood` (`jax_kalman_filter.py`) with a magnitude-relative jitter + PD guard; golden
+   likelihood preserved, 81 core tests pass. **This fix is kept** (it hardens the likelihood for
+   any sampler). See `ns_numerical_hygiene.md`.
+4. **Runtime is the killer — and it's fundamental.** Each Kalman likelihood eval is *cheap*
+   (~0.03 s at N=2, ~0.07 s at N=32, jitted, GPU; scales ~N²). But NS needs
+   `n_steps × num_inner_steps × num_delete` of them, and that product explodes:
+
+   | run | dim | wall (1× A100) |
+   |---|---|---|
+   | NUTS, 2-D MDC (recorded) | 2 | ~5–13 min |
+   | NUTS, full parameters | ~134 | **~2 days** |
+   | NS, accurate full-32, red-noise-only | 70 | **~2.5–7 weeks** |
+
+   NS is **~10–30× slower than NUTS**, at a *lower* dimension, and the gap grows with D.
+
+## Root reason
+
+NUTS uses the likelihood **gradient** (free from the JAX Kalman filter) to take long, informed
+trajectories → few evaluations. Slice-NS **discards the gradient** and explores by blind
+prior-volume shrinkage → many evaluations (`num_inner_steps` must scale with D for accuracy,
+compounding `n_steps ∝ D`). Same cheap likelihood; NS just calls it far too many times.
+(Note: SwiG / `blackjax.nsswig` goes the *wrong* way — ~`dim`× more evals per step. Confirmed.)
+
+## Decision
+
+- **Posterior inference: NUTS.** Fast, gradient-based, numerically clean (it stays in the typical
+  set, so it never hit the covariance pathology above).
+- **Evidence / Bayes factors (when needed): NOT slice-NS.** Pursue gradient- or posterior-reuse
+  estimators instead — in rough order of cheapness to try:
+  1. **Learned harmonic mean** (or similar) on the NUTS posterior we already pay for — logZ at
+     near-zero extra cost.
+  2. **Thermodynamic integration / stepping-stone** over a temperature ladder (gradient-based).
+  3. **Gradient-based nested sampling** (`blackjax.ns.from_mcmc` with an HMC inner kernel).
+- **Keep** the NS engine code (works, validated at small scale) and the `_log_likelihood`
+  robustness fix, but neither is the path to T3.4 at scale.
+
+## Revisit only if
+
+- A **gradient-based NS inner kernel** is implemented (could change the runtime story), or
+- The target problem shrinks enough (few pulsars / low D) that slice-NS is affordable, or
+- A materially faster likelihood or NS variant appears.
+
+Otherwise: **do not re-run the slice-NS scaling investigation.** The numbers above are the answer.
+
+## Artifacts (this study)
+
+Scripts under `scripts/`: `ns_scaling_dimension.py`, `gen_scaling_configs.py`,
+`ns_likelihood_microbench.py`, `ns_kernel_compare.py`, `ns_pathology_probe.py`,
+`ns_scaling_analyze.py`. Data under `outputs/scaling/`. Notes: `ns_numerical_hygiene.md`.
+Related memory: `project_ns_scaling_verdict`, `project_ns_numerical_hygiene`.

--- a/workflows/ng15_sgwb_demo/notes/ns_numerical_hygiene.md
+++ b/workflows/ng15_sgwb_demo/notes/ns_numerical_hygiene.md
@@ -1,0 +1,74 @@
+# NS numerical-hygiene issue: near-singular innovation covariance (deferred)
+
+**Status: FIXED 2026-07-10.** `_log_likelihood` (`jax_kalman_filter.py`) now symmetrises the
+innovation covariance, adds a magnitude-relative jitter (`1e-9·trace/n`), and returns `-inf` for
+a non-positive-definite covariance. Verified: the N=4 tail spike (8.6e8) is gone (max logL now at
+the true mode); golden likelihood 63618.93 preserved; 81 core tests pass. The fix is kept
+regardless of the (separate) decision to park nested sampling — it hardens the likelihood for any
+sampler. Original diagnosis retained below for context.
+
+## Symptom
+
+Running `blackjax` nested sampling (`sampler=blackjax`) on the real Argus Kalman likelihood,
+the sampler produces **spurious huge log-likelihoods (~1e8–1e11)** when it reaches certain
+prior-tail parameter regions, then locks onto that fake mode. Result: **garbage `logZ`** and
+**badly inflated runtime** (hours spent chasing the artefact). Observed in the scaling study's
+Stage 1b/2 subset runs:
+
+| config | logZ | verdict |
+|---|---|---|
+| N=2, D=2 (fixed noise) | 3792 | clean |
+| N=4, D=2 | 1.3e11 | pathological |
+| N=8, D=2 | 2.7e11 | pathological |
+| N=16, D=2 | ~1e5 climbing | pathological |
+| N=6, D=18 (red free) | live pt at 6.9e8 | pathological |
+| **N=32, D=2 (T2.6 config)** | 63780 (matches NUTS) | clean |
+
+## Root cause — it is NOT a pulsar-count / information issue
+
+The outcome is **non-monotonic in N** (N=2 clean, N=4–16 broken, N=32 clean), which rules out
+"fewer pulsars breaks it." The trigger is the **specific pulsar `J0437-4715`**, which my
+generator adds exactly at N=4 (pulsars are kept alphabetically). J0437-4715 is the
+highest-precision MSP in the set (smallest EQUAD, `~10^-7.35` ≈ 45 ns → tiny measurement
+covariance `R`).
+
+Mechanism: the Kalman innovation covariance `S = H P Hᵀ + R`. With tiny `R` (high-precision
+pulsar), `S` is dominated by the modeled state covariance `P`. Nested sampling explores the
+**entire prior globally**, so it wanders into tail regions (e.g. the wide
+`log10_ha ∈ [−16, −9]` amplitude prior) where `P` is mis-specified and `S` goes
+**near-singular** → `−½·logdet(S)` explodes into a spurious large positive log-likelihood.
+
+## Why this is NS-specific
+
+- **NUTS never hits it**: gradient guidance keeps NUTS in the typical set; it never visits the
+  ill-conditioned tail. (The 2-D MDC2 NUTS baseline was clean.) This is why the issue only
+  surfaced once we added a nested sampler.
+- The existing guard — a **6σ latent box** in `run_blackjax_nested_sampling`
+  (`bayesian_inference.py`, `latent_cutoff=6.0`) — is a **config-specific band-aid** tuned/
+  validated only for the 32-pulsar T2.6 problem. It does not generalise to other pulsar sets or
+  to higher-D (red-noise-free) configs, which expose more tail volume.
+
+## Fixes to consider (future work)
+
+Standard numerical hygiene; any of these, or a combination:
+1. **Regularise the innovation covariance** in `python/argus/jax_kalman_filter.py` — add jitter
+   to the diagonal of `S`, floor its condition number, or use a Joseph-form / Cholesky-with-
+   jitter update. This is the principled fix (makes the likelihood robust everywhere, benefiting
+   NS *and* any global sampler).
+2. **Magnitude guard on logL** — the current guard only rejects non-finite values; add a
+   sanity cap that rejects finite-but-implausible log-likelihoods (e.g. `|ll| ≫` plausible range).
+3. **Injection-informed / narrower priors** — the wide `log10_ha` prior is what lets NS reach
+   the pathological tail; a physically-motivated tighter prior reduces the exposure.
+4. **Adaptive latent box** instead of a fixed 6σ cutoff.
+
+## Relevance to the "is NS viable for full-PTA evidence?" question
+
+This is a **robustness blocker**, separate from the cost/runtime question: even where NS is
+affordable, it currently returns garbage evidence for most configs without per-config guard
+tuning. For NS (or any global-exploration evidence method) to be production-usable on Argus,
+the likelihood's covariance conditioning must be hardened (fix #1). Until then, coupled/subset
+NS evidence runs are unreliable. The cost-scaling study sidesteps this by measuring per-eval
+cost with a microbenchmark at sane parameters (no tail exploration).
+
+See also: `log.md` 2026-07-10 (T2.6 first documented the near-singular pathology + 6σ box),
+`t2.6_blackjax_ns_verdict.md`.

--- a/workflows/ng15_sgwb_demo/notes/t2.6_blackjax_ns_verdict.md
+++ b/workflows/ng15_sgwb_demo/notes/t2.6_blackjax_ns_verdict.md
@@ -1,0 +1,87 @@
+# T2.6 — blackjax nested-sampling feasibility spike: VERDICT
+
+**Date:** 2026-07-09. **Kill date:** 2026-07-11 (spike was time-boxed).
+**Verdict: PASS (method viable) — with two documented caveats (cost; OU cross-check deferred).**
+
+The blackjax nested sampler runs on Argus's differentiable Kalman likelihood and produces
+correct, reproducible Bayesian evidence (logZ). This unlocks the conditional **T3.4** HD-vs-CURN
+Bayes-factor upgrade (previously blocked: NUTS gives no evidence — "RISK B"). Two caveats gate
+*how* it should be used, below.
+
+## What was built
+- `bayesian_inference.run_blackjax_nested_sampling(..., mode="gwb")` — GWB evidence backend
+  (the `run_nested_sampling` GWB stub previously raised `NotImplementedError`).
+- `bayesian_inference._blackjax_ns_evidence(...)` — engine core (shared with the analytic gate).
+- `bayesian_inference._import_blackjax_ns()` — shim + import.
+- `workflow.py` dispatch: `[Data] sampler = blackjax`.
+- Configs/scripts: `configs/mdc2_blackjax_ns.ini`, `slurm_scripts/blackjax_ns_run.sh`,
+  `scripts/blackjax_ns_analytic_check.py`.
+
+## GATE 1 — dependency compatibility: PASS (no jax cascade)
+- `blackjax.nss` (nested slice sampling, Yallup et al. 2026) is **not in the PyPI wheels**
+  (1.4/1.5) — only in `blackjax-devs` main. Installed **`blackjax 1.6.dev --no-deps`**, which
+  leaves **jax 0.4.38 and numpy 1.26.4 untouched** (the `jax>=0.9` pin is for other blackjax
+  modules; the NS module uses only long-stable jax APIs).
+- One shim is required: alias `jax.shard_map = jax.experimental.shard_map.shard_map` before
+  `import blackjax` (its package `__init__`→`eca.py` imports the top-level `jax.shard_map`
+  promoted only in jax≥0.5). Handled in `_import_blackjax_ns()`.
+- **Zero blast radius:** Argus imports blackjax nowhere; argus/numpyro/jaxns all still import.
+  Pre-upgrade env snapshot saved for rollback.
+
+## GATE 2 — evidence correctness: PASS
+Analytic isotropic-Gaussian logZ reproduced through the library engine core:
+| d | logZ_true | logZ_NS |
+|---|-----------|---------|
+| 2 | −5.99 | −6.17 ± 0.08 |
+| 5 | −14.98 | −15.08 ± 0.12 |
+| 15 | −44.94 | −44.83 ± 0.20 |
+
+## GATE 3 — trustworthy + reproducible on a real Argus GWB likelihood: PASS (on MDC2)
+Validation dataset: **MDC2 dataset_2b** (the OU synthetic was unrecoverable — its feathers are
+gitignored and the ingest step is not in the workflow; see caveat 2). Red+white noise fixed →
+2 free GW params, with an existing NUTS baseline (`outputs/mdc2_smoke_wide/`).
+
+Key design point — **the "Jacobian trap" does not arise**: every free `numpyro.sample` site in
+the GWB model is `Normal(0,1)` (physical params are `deterministic` transforms), so the NS prior
+is an isotropic unit Gaussian and the likelihood is `log_density(model) − unit_normal_logprior`
+(numpyro's own model reused; no transform re-implementation).
+
+**Numerical pathology found and fixed.** Free NS slice-exploration reaches likelihood regions
+Argus's Kalman filter handles poorly (near-singular innovation covariance → spuriously huge
+log-likelihood), unlike gradient-guided NUTS which stays in the typical set. A 33×33 grid over
+the latent prior showed the only spurious point (L=75071 ≫ mode≈63779) sits at |z|=6.5, in the
+tails; within |z|≤6 the surface is clean and peaks at the true mode. Fix: **bounded latent prior
+at 6σ** (truncated-N(0,1) mass loss ~2e-9/dim → evidence unchanged) + non-finite sanitation.
+After the fix the run converges monotonically and terminates cleanly.
+
+- logZ = **63780.97 ± 0.16** (converged; `logZ_live−logZ` decreased monotonically
+  825 → 92 → 11 → −3, confirming the tail pathology is gone). A longer earlier run
+  (num_live=300, dlogz=−5) gave logZ = 63781.17 ± 0.13 — consistent.
+- **NS posterior reproduces the NUTS baseline exactly** (mean AND std):
+
+  | param | blackjax NS | NUTS |
+  |-------|-------------|------|
+  | log10_ha | −12.882 ± 0.050 | −12.88 ± 0.05 |
+  | log10_gamma_a | −8.105 ± 0.134 | −8.1 ± 0.13 |
+
+- A posterior-extraction bug was found and fixed: `to_physical` traces the full model (which
+  runs the joint Kalman likelihood), so `jax.vmap` over thousands of draws materialised all
+  intermediates at once and OOM'd the 80 GB A100 (~106 GB alloc). Switched to sequential
+  `jax.lax.map` (one draw's memory footprint). Evidence was unaffected — the OOM was strictly
+  in post-processing after logZ had converged.
+
+## Caveats (how to use it, not blockers)
+1. **Cost.** On the 32-pulsar MDC2 likelihood, one 2-D run took ~1 h on an A100 (~20–100 s/step,
+   rising late as live points cluster). The intended Stage-3 target is only 6 pulsars (cheaper),
+   and `num_delete`/`num_inner_steps`/`num_live` trade cost vs accuracy. Budget accordingly;
+   this is not a same-minute sampler.
+2. **OU-synthetic cross-check deferred.** The task's preferred correctly-specified check (OU
+   injection vs the T2.3 NUTS posterior) needs the OU feathers, which are gone and require the
+   ingest→align→inject pipeline rebuilt (the ingest step is not in the workflow scripts). MDC2
+   substitutes as a real-GWB dataset with a NUTS baseline; the OU check remains a follow-up.
+
+## Recommendation
+Proceed with **T3.4** (HD-vs-CURN Bayes factor) using this backend, on the 6-pulsar Stage-3
+target, budgeting GPU time per caveat 1. Reproducibility-across-seeds and the OU cross-check
+should be completed as part of T3.4 setup. Keep NUTS as the primary posterior sampler; use NS
+for evidence/model comparison.

--- a/workflows/ng15_sgwb_demo/scripts/blackjax_ns_analytic_check.py
+++ b/workflows/ng15_sgwb_demo/scripts/blackjax_ns_analytic_check.py
@@ -20,6 +20,7 @@ Run (CPU):
 Exit code 0 iff every dimension's recovered logZ agrees with the closed form within
 tolerance (``|logZ_est - logZ_true| < max(3*logZ_err, ATOL)``).
 """
+
 import argparse
 import math
 import time
@@ -47,9 +48,7 @@ def run_dim(d, half_width=10.0, num_live=500, seed=0, dlogz=-5.0):
 
     key = jax.random.PRNGKey(seed)
     key, subkey = jax.random.split(key)
-    init_particles = jax.random.uniform(
-        subkey, (num_live, d), minval=lo, maxval=hi
-    )
+    init_particles = jax.random.uniform(subkey, (num_live, d), minval=lo, maxval=hi)
 
     t0 = time.time()
     res = _blackjax_ns_evidence(
@@ -75,8 +74,10 @@ def main():
     print("=" * 78)
     print("T2.6 GATE 2: blackjax NS evidence vs analytic Gaussian logZ")
     print("=" * 78)
-    print(f"{'d':>4} {'logZ_true':>12} {'logZ_est':>12} {'logZ_err':>10} "
-          f"{'|err|':>8} {'steps':>8} {'wall_s':>8}  verdict")
+    print(
+        f"{'d':>4} {'logZ_true':>12} {'logZ_est':>12} {'logZ_err':>10} "
+        f"{'|err|':>8} {'steps':>8} {'wall_s':>8}  verdict"
+    )
 
     all_ok = True
     for d in args.dims:
@@ -86,9 +87,11 @@ def main():
         abs_err = abs(est - logZ_true)
         ok = abs_err < max(3.0 * err, args.atol)
         all_ok &= ok
-        print(f"{d:>4} {logZ_true:>12.3f} {est:>12.3f} {err:>10.3f} "
-              f"{abs_err:>8.3f} {res['n_steps']:>8d} {res['wall_s']:>8.1f}  "
-              f"{'PASS' if ok else 'FAIL'}")
+        print(
+            f"{d:>4} {logZ_true:>12.3f} {est:>12.3f} {err:>10.3f} "
+            f"{abs_err:>8.3f} {res['n_steps']:>8d} {res['wall_s']:>8.1f}  "
+            f"{'PASS' if ok else 'FAIL'}"
+        )
 
     print("=" * 78)
     print(f"GATE 2: {'PASS' if all_ok else 'FAIL'}")

--- a/workflows/ng15_sgwb_demo/scripts/blackjax_ns_analytic_check.py
+++ b/workflows/ng15_sgwb_demo/scripts/blackjax_ns_analytic_check.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""T2.6 GATE 2 — validate the blackjax nested-sampling evidence engine on a problem
+with an analytically known logZ, before trusting it on the GWB likelihood.
+
+This calls the *same* library engine core (``argus.bayesian_inference._blackjax_ns_evidence``)
+that :func:`run_blackjax_nested_sampling` uses on real data, so a pass here certifies the
+exact code path used for inference — not a bespoke re-implementation.
+
+Problem: isotropic unit-Gaussian likelihood ``L(x) = N(x; 0, I_d)`` under a uniform prior
+on the box ``[-B, B]^d`` (with B large enough to contain essentially all the Gaussian mass).
+The evidence is then
+
+    Z = int L(x) p(x) dx = (1 / (2B)^d) * int N(x;0,I) dx  ~=  (2B)^{-d}
+    logZ_true = -d * log(2B).
+
+Run (CPU):
+    JAX_PLATFORMS=cpu PYTHONPATH=<repo>/python \
+        python workflows/ng15_sgwb_demo/scripts/blackjax_ns_analytic_check.py
+
+Exit code 0 iff every dimension's recovered logZ agrees with the closed form within
+tolerance (``|logZ_est - logZ_true| < max(3*logZ_err, ATOL)``).
+"""
+import argparse
+import math
+import time
+
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+from argus.bayesian_inference import _blackjax_ns_evidence  # noqa: E402
+
+
+def run_dim(d, half_width=10.0, num_live=500, seed=0, dlogz=-5.0):
+    """Run NS on the d-dimensional analytic Gaussian; return (logZ_true, result)."""
+    lo, hi = -half_width, half_width
+    log_box_volume = d * math.log(hi - lo)
+    logZ_true = -log_box_volume  # Gaussian integrates to ~1 over the wide box
+
+    def logprior_fn(x):
+        inside = jnp.all((x >= lo) & (x <= hi))
+        return jnp.where(inside, -log_box_volume, -jnp.inf)
+
+    def loglikelihood_fn(x):
+        return -0.5 * jnp.sum(x**2) - 0.5 * d * math.log(2.0 * math.pi)
+
+    key = jax.random.PRNGKey(seed)
+    key, subkey = jax.random.split(key)
+    init_particles = jax.random.uniform(
+        subkey, (num_live, d), minval=lo, maxval=hi
+    )
+
+    t0 = time.time()
+    res = _blackjax_ns_evidence(
+        logprior_fn,
+        loglikelihood_fn,
+        init_particles,
+        num_delete=1,
+        num_inner_steps=max(5, 2 * d),
+        dlogz=dlogz,
+        rng_key=key,
+    )
+    res["wall_s"] = time.time() - t0
+    return logZ_true, res
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dims", type=int, nargs="+", default=[2, 5, 15])
+    parser.add_argument("--num-live", type=int, default=500)
+    parser.add_argument("--atol", type=float, default=0.5)
+    args = parser.parse_args()
+
+    print("=" * 78)
+    print("T2.6 GATE 2: blackjax NS evidence vs analytic Gaussian logZ")
+    print("=" * 78)
+    print(f"{'d':>4} {'logZ_true':>12} {'logZ_est':>12} {'logZ_err':>10} "
+          f"{'|err|':>8} {'steps':>8} {'wall_s':>8}  verdict")
+
+    all_ok = True
+    for d in args.dims:
+        logZ_true, res = run_dim(d, num_live=args.num_live)
+        est = res["logZ"]
+        err = res["logZ_err"]
+        abs_err = abs(est - logZ_true)
+        ok = abs_err < max(3.0 * err, args.atol)
+        all_ok &= ok
+        print(f"{d:>4} {logZ_true:>12.3f} {est:>12.3f} {err:>10.3f} "
+              f"{abs_err:>8.3f} {res['n_steps']:>8d} {res['wall_s']:>8.1f}  "
+              f"{'PASS' if ok else 'FAIL'}")
+
+    print("=" * 78)
+    print(f"GATE 2: {'PASS' if all_ok else 'FAIL'}")
+    raise SystemExit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/ng15_sgwb_demo/scripts/gen_scaling_configs.py
+++ b/workflows/ng15_sgwb_demo/scripts/gen_scaling_configs.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+"""NS cost-scaling study — config generator for the GPU stages (1b, 2, 3).
+
+Clones the T2.6 validation config ``configs/mdc2_blackjax_ns.ini`` and stamps out one
+derived ``.ini`` per grid point, varying the two cost axes and the sampler knobs:
+
+  * N_pulsars   — via ``[Data] excluded_psrs`` (subset MDC2 dataset_2b down to N).
+  * dimension D — via the noise-fix toggles in ``[PriorModel]``:
+        dmode=fixed      red+white FIXED   -> D = 2                 (T2.6 floor)
+        dmode=red_free   red FREE, white FIXED -> D = 2 + 4 + 2N    (hierarchical)
+        dmode=white_free white FREE, red FIXED -> D = 2 + 2N
+        dmode=all_free   both FREE         -> D = 4N + 6            (full model)
+    Red noise is freed by blanking ``spin_injections_path``; white noise by blanking
+    ``noise_params_path`` (see prior_models.py: non-empty path => that group is fixed).
+  * NS knobs    — ``[NestedSampler] num_live_points / num_delete / num_inner_steps``.
+    num_inner_steps is set to max(5, INNER_MULT*D). The Stage-1a diagnostic found the
+    engine's default (2*D) is too few for *accurate evidence* at high D (logZ bias grows
+    with dimension); 6*D recovers accuracy and, per-eval, is cheaper than compensating with
+    more live points. Stage 3 refines this frontier.
+
+Dimension arithmetic mirrors ``parameter_sampling.count_free_parameters``:
+    global   = 2 GW (log10_ha, log10_gamma_a) + 4 red-noise hyperparameters (when red free)
+    per-psr  = gamma_p + sigma_p (red) + efac + equad (white)
+
+Writes derived configs into ``outputs/derived_configs/`` and prints one config path per
+line (consumed by slurm_scripts/ns_scaling_run.sh). Pure config generation — no compute.
+
+Usage:
+    python gen_scaling_configs.py --stage 1b        # D=2, N in {2,4,8,16,32}
+    python gen_scaling_configs.py --stage 2         # red_free, N in {6,16,32}
+    python gen_scaling_configs.py --stage 3         # red_free N=16, knob sweep
+"""
+import argparse
+import configparser
+import csv
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+WORKFLOW = os.path.dirname(HERE)
+TEMPLATE = os.path.join(WORKFLOW, "configs", "mdc2_blackjax_ns.ini")
+DERIVED_DIR = os.path.join(WORKFLOW, "outputs", "derived_configs")
+OUTPUT_DIR = os.path.join(WORKFLOW, "outputs")
+
+# Always drop this pulsar (the T2.6 validation excluded it); N is chosen from the rest.
+ALWAYS_EXCLUDE = "J1640+2224"
+
+# num_inner_steps = INNER_MULT * D (Stage-1a diagnostic: 2*D biases logZ, 6*D is accurate).
+INNER_MULT = 6
+
+
+def _load_template():
+    cp = configparser.ConfigParser(interpolation=None)
+    cp.optionxform = str  # preserve key case
+    cp.read(TEMPLATE)
+    return cp
+
+
+def _pulsar_list(data_path):
+    """Sorted pulsar names (from .par files) in the dataset directory."""
+    names = sorted(
+        f[:-4] for f in os.listdir(data_path) if f.endswith(".par")
+    )
+    return names
+
+
+def dimension(n, dmode):
+    if dmode == "fixed":
+        return 2
+    if dmode == "red_free":
+        return 2 + 4 + 2 * n
+    if dmode == "white_free":
+        return 2 + 2 * n
+    if dmode == "all_free":
+        return 4 * n + 6
+    raise ValueError(f"unknown dmode {dmode!r}")
+
+
+def make_config(n, dmode, num_live, num_delete, seed,
+                num_inner_steps=None, output_id=None):
+    """Return (output_id, ConfigParser) for one grid point."""
+    cp = _load_template()
+    data_path = cp.get("Data", "data_path")
+    all_psrs = _pulsar_list(data_path)
+    candidates = [p for p in all_psrs if p != ALWAYS_EXCLUDE]
+    if n > len(candidates):
+        raise ValueError(f"requested N={n} but only {len(candidates)} pulsars available")
+    keep = candidates[:n]
+    excluded = [ALWAYS_EXCLUDE] + [p for p in candidates if p not in keep]
+    # Comma-only (no space): utils.get_noise_parameters splits excluded_psrs on "," WITHOUT
+    # stripping (unlike workflow.py's data loader), so a ", " separator leaves leading spaces
+    # that fail the substring match -> the fixed noise arrays would keep all 32 pulsars while
+    # the data is subset to N, giving a (32,) vs (N,) broadcast error. Comma-only sidesteps it.
+    cp.set("Data", "excluded_psrs", ",".join(excluded))
+
+    D = dimension(n, dmode)
+    if num_inner_steps is None:
+        num_inner_steps = max(5, INNER_MULT * D)
+
+    # Noise-fix toggles (blank path => that group becomes free/sampled).
+    if dmode in ("red_free", "all_free"):
+        cp.set("PriorModel", "spin_injections_path", "")
+    if dmode in ("white_free", "all_free"):
+        cp.set("PriorModel", "noise_params_path", "")
+
+    cp.set("NestedSampler", "num_live_points", str(num_live))
+    cp.set("NestedSampler", "num_delete", str(num_delete))
+    cp.set("NestedSampler", "num_inner_steps", str(num_inner_steps))
+    cp.set("NestedSampler", "seed", str(seed))
+
+    if output_id is None:
+        output_id = (f"ns_scal_{dmode}_N{n:02d}_D{D:03d}"
+                     f"_nl{num_live}_nd{num_delete}_s{seed}")
+    cp.set("Output", "output_dir", OUTPUT_DIR + os.sep)
+    cp.set("Output", "output_id", output_id)
+    return output_id, cp, D, num_inner_steps
+
+
+def _points_for_stage(stage):
+    """Return list of dicts of make_config kwargs for a named stage."""
+    if stage == "1b":  # likelihood-cost vs N, dimension held at D=2
+        return [dict(n=n, dmode="fixed", num_live=500, num_delete=25, seed=42)
+                for n in (2, 4, 8, 16, 32)]
+    if stage == "2":   # realistic coupled proxy: red noise free, climb N (and thus D)
+        return [dict(n=n, dmode="red_free", num_live=500, num_delete=25, seed=42)
+                for n in (6, 16, 32)]
+    if stage == "3":   # sampler-knob frontier at one representative config (N=16, red_free)
+        pts = []
+        for num_delete in (25, 50, 100):
+            for num_live in (250, 500, 1000):
+                pts.append(dict(n=16, dmode="red_free",
+                                num_live=num_live, num_delete=num_delete, seed=42))
+        return pts
+    raise ValueError(f"unknown stage {stage!r}")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--stage", choices=["1b", "2", "3"], required=True)
+    p.add_argument("--out-dir", default=DERIVED_DIR)
+    p.add_argument("--manifest", default=None,
+                   help="CSV manifest path (default: <out-dir>/manifest_stage<stage>.csv)")
+    args = p.parse_args()
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    manifest = args.manifest or os.path.join(
+        args.out_dir, f"manifest_stage{args.stage}.csv")
+
+    rows = []
+    paths = []
+    for kw in _points_for_stage(args.stage):
+        output_id, cp, D, nis = make_config(**kw)
+        path = os.path.join(args.out_dir, f"{output_id}.ini")
+        with open(path, "w") as f:
+            cp.write(f)
+        paths.append(path)
+        rows.append({
+            "output_id": output_id, "config_path": path,
+            "N": kw["n"], "dmode": kw["dmode"], "D": D,
+            "num_live": kw["num_live"], "num_delete": kw["num_delete"],
+            "num_inner_steps": nis, "seed": kw["seed"],
+        })
+
+    with open(manifest, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+
+    # stderr: human summary; stdout: config paths (one per line) for the SLURM runner.
+    import sys
+    print(f"# stage {args.stage}: {len(paths)} configs -> {args.out_dir}", file=sys.stderr)
+    print(f"# manifest: {manifest}", file=sys.stderr)
+    for r in rows:
+        print(f"#   {r['output_id']}  (N={r['N']} D={r['D']} "
+              f"nl={r['num_live']} nd={r['num_delete']} nis={r['num_inner_steps']})",
+              file=sys.stderr)
+    for path in paths:
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/ng15_sgwb_demo/scripts/gen_scaling_configs.py
+++ b/workflows/ng15_sgwb_demo/scripts/gen_scaling_configs.py
@@ -30,6 +30,7 @@ Usage:
     python gen_scaling_configs.py --stage 2         # red_free, N in {6,16,32}
     python gen_scaling_configs.py --stage 3         # red_free N=16, knob sweep
 """
+
 import argparse
 import configparser
 import csv
@@ -57,9 +58,7 @@ def _load_template():
 
 def _pulsar_list(data_path):
     """Sorted pulsar names (from .par files) in the dataset directory."""
-    names = sorted(
-        f[:-4] for f in os.listdir(data_path) if f.endswith(".par")
-    )
+    names = sorted(f[:-4] for f in os.listdir(data_path) if f.endswith(".par"))
     return names
 
 
@@ -75,15 +74,18 @@ def dimension(n, dmode):
     raise ValueError(f"unknown dmode {dmode!r}")
 
 
-def make_config(n, dmode, num_live, num_delete, seed,
-                num_inner_steps=None, output_id=None):
+def make_config(
+    n, dmode, num_live, num_delete, seed, num_inner_steps=None, output_id=None
+):
     """Return (output_id, ConfigParser) for one grid point."""
     cp = _load_template()
     data_path = cp.get("Data", "data_path")
     all_psrs = _pulsar_list(data_path)
     candidates = [p for p in all_psrs if p != ALWAYS_EXCLUDE]
     if n > len(candidates):
-        raise ValueError(f"requested N={n} but only {len(candidates)} pulsars available")
+        raise ValueError(
+            f"requested N={n} but only {len(candidates)} pulsars available"
+        )
     keep = candidates[:n]
     excluded = [ALWAYS_EXCLUDE] + [p for p in candidates if p not in keep]
     # Comma-only (no space): utils.get_noise_parameters splits excluded_psrs on "," WITHOUT
@@ -108,8 +110,9 @@ def make_config(n, dmode, num_live, num_delete, seed,
     cp.set("NestedSampler", "seed", str(seed))
 
     if output_id is None:
-        output_id = (f"ns_scal_{dmode}_N{n:02d}_D{D:03d}"
-                     f"_nl{num_live}_nd{num_delete}_s{seed}")
+        output_id = (
+            f"ns_scal_{dmode}_N{n:02d}_D{D:03d}" f"_nl{num_live}_nd{num_delete}_s{seed}"
+        )
     cp.set("Output", "output_dir", OUTPUT_DIR + os.sep)
     cp.set("Output", "output_id", output_id)
     return output_id, cp, D, num_inner_steps
@@ -118,17 +121,30 @@ def make_config(n, dmode, num_live, num_delete, seed,
 def _points_for_stage(stage):
     """Return list of dicts of make_config kwargs for a named stage."""
     if stage == "1b":  # likelihood-cost vs N, dimension held at D=2
-        return [dict(n=n, dmode="fixed", num_live=500, num_delete=25, seed=42)
-                for n in (2, 4, 8, 16, 32)]
-    if stage == "2":   # realistic coupled proxy: red noise free, climb N (and thus D)
-        return [dict(n=n, dmode="red_free", num_live=500, num_delete=25, seed=42)
-                for n in (6, 16, 32)]
-    if stage == "3":   # sampler-knob frontier at one representative config (N=16, red_free)
+        return [
+            dict(n=n, dmode="fixed", num_live=500, num_delete=25, seed=42)
+            for n in (2, 4, 8, 16, 32)
+        ]
+    if stage == "2":  # realistic coupled proxy: red noise free, climb N (and thus D)
+        return [
+            dict(n=n, dmode="red_free", num_live=500, num_delete=25, seed=42)
+            for n in (6, 16, 32)
+        ]
+    if (
+        stage == "3"
+    ):  # sampler-knob frontier at one representative config (N=16, red_free)
         pts = []
         for num_delete in (25, 50, 100):
             for num_live in (250, 500, 1000):
-                pts.append(dict(n=16, dmode="red_free",
-                                num_live=num_live, num_delete=num_delete, seed=42))
+                pts.append(
+                    dict(
+                        n=16,
+                        dmode="red_free",
+                        num_live=num_live,
+                        num_delete=num_delete,
+                        seed=42,
+                    )
+                )
         return pts
     raise ValueError(f"unknown stage {stage!r}")
 
@@ -137,13 +153,17 @@ def main():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--stage", choices=["1b", "2", "3"], required=True)
     p.add_argument("--out-dir", default=DERIVED_DIR)
-    p.add_argument("--manifest", default=None,
-                   help="CSV manifest path (default: <out-dir>/manifest_stage<stage>.csv)")
+    p.add_argument(
+        "--manifest",
+        default=None,
+        help="CSV manifest path (default: <out-dir>/manifest_stage<stage>.csv)",
+    )
     args = p.parse_args()
 
     os.makedirs(args.out_dir, exist_ok=True)
     manifest = args.manifest or os.path.join(
-        args.out_dir, f"manifest_stage{args.stage}.csv")
+        args.out_dir, f"manifest_stage{args.stage}.csv"
+    )
 
     rows = []
     paths = []
@@ -153,12 +173,19 @@ def main():
         with open(path, "w") as f:
             cp.write(f)
         paths.append(path)
-        rows.append({
-            "output_id": output_id, "config_path": path,
-            "N": kw["n"], "dmode": kw["dmode"], "D": D,
-            "num_live": kw["num_live"], "num_delete": kw["num_delete"],
-            "num_inner_steps": nis, "seed": kw["seed"],
-        })
+        rows.append(
+            {
+                "output_id": output_id,
+                "config_path": path,
+                "N": kw["n"],
+                "dmode": kw["dmode"],
+                "D": D,
+                "num_live": kw["num_live"],
+                "num_delete": kw["num_delete"],
+                "num_inner_steps": nis,
+                "seed": kw["seed"],
+            }
+        )
 
     with open(manifest, "w", newline="") as f:
         w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
@@ -167,12 +194,17 @@ def main():
 
     # stderr: human summary; stdout: config paths (one per line) for the SLURM runner.
     import sys
-    print(f"# stage {args.stage}: {len(paths)} configs -> {args.out_dir}", file=sys.stderr)
+
+    print(
+        f"# stage {args.stage}: {len(paths)} configs -> {args.out_dir}", file=sys.stderr
+    )
     print(f"# manifest: {manifest}", file=sys.stderr)
     for r in rows:
-        print(f"#   {r['output_id']}  (N={r['N']} D={r['D']} "
-              f"nl={r['num_live']} nd={r['num_delete']} nis={r['num_inner_steps']})",
-              file=sys.stderr)
+        print(
+            f"#   {r['output_id']}  (N={r['N']} D={r['D']} "
+            f"nl={r['num_live']} nd={r['num_delete']} nis={r['num_inner_steps']})",
+            file=sys.stderr,
+        )
     for path in paths:
         print(path)
 

--- a/workflows/ng15_sgwb_demo/scripts/ns_kernel_compare.py
+++ b/workflows/ng15_sgwb_demo/scripts/ns_kernel_compare.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+"""NS cost-scaling study — inner-kernel comparison: monolithic slice vs slice-within-Gibbs.
+
+Tests the hypothesis (Yallup 2026, arXiv:2602.17414) that wiring hierarchical *structure*
+into the NS inner kernel — an axis-aligned slice-within-Gibbs (SwiG) coordinate sweep
+(``blackjax.nsswig``) — mixes better per likelihood evaluation than the default monolithic
+hit-and-run slice (``blackjax.nss``), and so needs fewer inner steps / live points for the
+same evidence accuracy at high dimension. If so, it directly lowers the full-PTA runtime.
+
+We compare on the likelihood-free analytic Gaussian (known logZ = -d*log(2B)) so the only
+difference is the kernel. For each dimension we run both kernels at a *stress* inner-step
+budget (default 2*d, where the monolithic slice is known to bias logZ upward) and report:
+  |logZ - logZ_true| (accuracy), n_steps, wall_s.
+A kernel that stays accurate at 2*d while the other needs ~6*d is the more efficient choice.
+
+Run (CPU, fast):
+    JAX_PLATFORMS=cpu PYTHONPATH=<repo>/python \
+        python workflows/ng15_sgwb_demo/scripts/ns_kernel_compare.py --dims 15 30 60
+"""
+import argparse
+import csv
+import os
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+from ns_scaling_dimension import run_dim, DEFAULT_OUT  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dims", type=int, nargs="+", default=[15, 30, 60])
+    ap.add_argument("--num-live", type=int, default=500)
+    ap.add_argument("--num-delete", type=int, default=25)
+    ap.add_argument("--inner-mult", type=float, default=2.0,
+                    help="Inner steps = inner_mult*d (default 2 = the stress setting where "
+                         "monolithic slice biases logZ; the discriminating test).")
+    ap.add_argument("--atol", type=float, default=0.5)
+    ap.add_argument("--out", default=os.path.join(DEFAULT_OUT, "kernel_compare.csv"))
+    args = ap.parse_args()
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+
+    print("=" * 90)
+    print("NS inner-kernel comparison: nss (monolithic slice) vs nsswig (slice-within-Gibbs)")
+    print(f"num_live={args.num_live}  num_delete={args.num_delete}  "
+          f"inner_steps={args.inner_mult}*d")
+    print("=" * 90)
+    print(f"{'d':>5} {'kernel':>8} {'logZ_true':>11} {'logZ_est':>11} {'|err|':>8} "
+          f"{'inner':>6} {'steps':>7} {'wall_s':>8}  verdict")
+
+    rows = []
+    for d in args.dims:
+        for kernel in ("nss", "nsswig"):
+            logZ_true, res = run_dim(
+                d, num_live=args.num_live, num_delete=args.num_delete,
+                inner_mult=args.inner_mult, kernel=kernel,
+            )
+            est = res["logZ"]
+            err = res["logZ_err"]
+            abs_err = abs(est - logZ_true)
+            ok = abs_err < max(3.0 * err, args.atol)
+            rows.append({
+                "d": d, "kernel": kernel, "logZ_true": logZ_true, "logZ_est": est,
+                "logZ_err": err, "abs_err": abs_err,
+                "num_inner_steps": res["num_inner_steps"], "n_steps": int(res["n_steps"]),
+                "wall_s": res["wall_s"], "ok": int(ok),
+            })
+            print(f"{d:>5} {kernel:>8} {logZ_true:>11.3f} {est:>11.3f} {abs_err:>8.3f} "
+                  f"{res['num_inner_steps']:>6d} {res['n_steps']:>7d} {res['wall_s']:>8.1f}"
+                  f"  {'PASS' if ok else 'FAIL'}")
+
+    with open(args.out, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+    print("=" * 90)
+    print(f"CSV -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/ng15_sgwb_demo/scripts/ns_kernel_compare.py
+++ b/workflows/ng15_sgwb_demo/scripts/ns_kernel_compare.py
@@ -17,6 +17,7 @@ Run (CPU, fast):
     JAX_PLATFORMS=cpu PYTHONPATH=<repo>/python \
         python workflows/ng15_sgwb_demo/scripts/ns_kernel_compare.py --dims 15 30 60
 """
+
 import argparse
 import csv
 import os
@@ -33,42 +34,65 @@ def main():
     ap.add_argument("--dims", type=int, nargs="+", default=[15, 30, 60])
     ap.add_argument("--num-live", type=int, default=500)
     ap.add_argument("--num-delete", type=int, default=25)
-    ap.add_argument("--inner-mult", type=float, default=2.0,
-                    help="Inner steps = inner_mult*d (default 2 = the stress setting where "
-                         "monolithic slice biases logZ; the discriminating test).")
+    ap.add_argument(
+        "--inner-mult",
+        type=float,
+        default=2.0,
+        help="Inner steps = inner_mult*d (default 2 = the stress setting where "
+        "monolithic slice biases logZ; the discriminating test).",
+    )
     ap.add_argument("--atol", type=float, default=0.5)
     ap.add_argument("--out", default=os.path.join(DEFAULT_OUT, "kernel_compare.csv"))
     args = ap.parse_args()
     os.makedirs(os.path.dirname(args.out), exist_ok=True)
 
     print("=" * 90)
-    print("NS inner-kernel comparison: nss (monolithic slice) vs nsswig (slice-within-Gibbs)")
-    print(f"num_live={args.num_live}  num_delete={args.num_delete}  "
-          f"inner_steps={args.inner_mult}*d")
+    print(
+        "NS inner-kernel comparison: nss (monolithic slice) vs nsswig (slice-within-Gibbs)"
+    )
+    print(
+        f"num_live={args.num_live}  num_delete={args.num_delete}  "
+        f"inner_steps={args.inner_mult}*d"
+    )
     print("=" * 90)
-    print(f"{'d':>5} {'kernel':>8} {'logZ_true':>11} {'logZ_est':>11} {'|err|':>8} "
-          f"{'inner':>6} {'steps':>7} {'wall_s':>8}  verdict")
+    print(
+        f"{'d':>5} {'kernel':>8} {'logZ_true':>11} {'logZ_est':>11} {'|err|':>8} "
+        f"{'inner':>6} {'steps':>7} {'wall_s':>8}  verdict"
+    )
 
     rows = []
     for d in args.dims:
         for kernel in ("nss", "nsswig"):
             logZ_true, res = run_dim(
-                d, num_live=args.num_live, num_delete=args.num_delete,
-                inner_mult=args.inner_mult, kernel=kernel,
+                d,
+                num_live=args.num_live,
+                num_delete=args.num_delete,
+                inner_mult=args.inner_mult,
+                kernel=kernel,
             )
             est = res["logZ"]
             err = res["logZ_err"]
             abs_err = abs(est - logZ_true)
             ok = abs_err < max(3.0 * err, args.atol)
-            rows.append({
-                "d": d, "kernel": kernel, "logZ_true": logZ_true, "logZ_est": est,
-                "logZ_err": err, "abs_err": abs_err,
-                "num_inner_steps": res["num_inner_steps"], "n_steps": int(res["n_steps"]),
-                "wall_s": res["wall_s"], "ok": int(ok),
-            })
-            print(f"{d:>5} {kernel:>8} {logZ_true:>11.3f} {est:>11.3f} {abs_err:>8.3f} "
-                  f"{res['num_inner_steps']:>6d} {res['n_steps']:>7d} {res['wall_s']:>8.1f}"
-                  f"  {'PASS' if ok else 'FAIL'}")
+            rows.append(
+                {
+                    "d": d,
+                    "kernel": kernel,
+                    "logZ_true": logZ_true,
+                    "logZ_est": est,
+                    "logZ_err": err,
+                    "abs_err": abs_err,
+                    "num_inner_steps": res["num_inner_steps"],
+                    "n_steps": int(res["n_steps"]),
+                    "wall_s": res["wall_s"],
+                    "ok": int(ok),
+                }
+            )
+            print(
+                f"{d:>5} {kernel:>8} {logZ_true:>11.3f} {est:>11.3f} {abs_err:>8.3f} "
+                f"{res['num_inner_steps']:>6d} {res['n_steps']:>7d} {res['wall_s']:>8.1f}"
+                f"  {'PASS' if ok else 'FAIL'}"
+            )
 
     with open(args.out, "w", newline="") as f:
         w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))

--- a/workflows/ng15_sgwb_demo/scripts/ns_likelihood_microbench.py
+++ b/workflows/ng15_sgwb_demo/scripts/ns_likelihood_microbench.py
@@ -16,6 +16,7 @@ wall times. Fits c(N) ~ a * N^b.
 Run on GPU (the real venue) via SLURM, or on CPU for a quick check of small N:
     JAX_PLATFORMS=cpu PYTHONPATH=<repo>/python python ns_likelihood_microbench.py --N 2 4 8
 """
+
 import argparse
 import csv
 import logging
@@ -52,14 +53,18 @@ def bench_one(config_path, batch=25, repeats=20, warmup=3):
     """Time one full-model log-density (Kalman) eval for the pulsar set in `config_path`."""
     cp = _load_cfg(config_path)
     # JaxKalmanFilter uses argus's global logger, which must be initialised first.
-    logger = io_manager.setup_single_logger(cp, output_dir=None, enable_file_logging=False)
+    logger = io_manager.setup_single_logger(
+        cp, output_dir=None, enable_file_logging=False
+    )
 
     pulsar_data, KF = workflow.setup_data_and_kalman_filter(
-        cp, logger, use_gw=True, signal_model="gwb")
+        cp, logger, use_gw=True, signal_model="gwb"
+    )
     n_pulsars = len(pulsar_data["metadata"])
     efac, equad, sigma_p, gamma_p = utils.get_noise_parameters(cp)
     prior_specs = prior_models.get_prior_model_specs(
-        cp, n_pulsars, sigma_p, gamma_p, efac, equad, mode="gwb")
+        cp, n_pulsars, sigma_p, gamma_p, efac, equad, mode="gwb"
+    )
 
     def model():
         numpyro_model(KF, prior_specs, n_pulsars)
@@ -67,11 +72,14 @@ def bench_one(config_path, batch=25, repeats=20, warmup=3):
     # Latent sites (all reparameterized Normal(0,1)); evaluate at z=0 = prior centre (sane).
     key = jax.random.PRNGKey(0)
     tr = trace(seed(model, key)).get_trace()
-    latents = {name: jnp.zeros(jnp.shape(site["value"]))
-               for name, site in tr.items()
-               if site["type"] == "sample" and not site.get("is_observed", False)}
-    ndim = int(sum(int(np.prod(jnp.shape(v))) if jnp.shape(v) else 1
-                   for v in latents.values()))
+    latents = {
+        name: jnp.zeros(jnp.shape(site["value"]))
+        for name, site in tr.items()
+        if site["type"] == "sample" and not site.get("is_observed", False)
+    }
+    ndim = int(
+        sum(int(np.prod(jnp.shape(v))) if jnp.shape(v) else 1 for v in latents.values())
+    )
 
     def loglik(params):
         lp, _ = log_density(model, (), {}, params)
@@ -79,11 +87,13 @@ def bench_one(config_path, batch=25, repeats=20, warmup=3):
 
     f1 = jax.jit(loglik)
     fB = jax.jit(jax.vmap(loglik))
-    batch_params = {k: jnp.broadcast_to(v, (batch,) + jnp.shape(v))
-                    for k, v in latents.items()}
+    batch_params = {
+        k: jnp.broadcast_to(v, (batch,) + jnp.shape(v)) for k, v in latents.items()
+    }
 
     # single-eval timing
-    v = f1(latents); v.block_until_ready()
+    v = f1(latents)
+    v.block_until_ready()
     for _ in range(warmup):
         f1(latents).block_until_ready()
     t0 = time.perf_counter()
@@ -92,7 +102,8 @@ def bench_one(config_path, batch=25, repeats=20, warmup=3):
     t_single = (time.perf_counter() - t0) / repeats
 
     # batched-eval timing (vmap over `batch` particles, like NS's num_delete)
-    vb = fB(batch_params); vb.block_until_ready()
+    vb = fB(batch_params)
+    vb.block_until_ready()
     for _ in range(warmup):
         fB(batch_params).block_until_ready()
     t0 = time.perf_counter()
@@ -101,9 +112,12 @@ def bench_one(config_path, batch=25, repeats=20, warmup=3):
     t_batch = (time.perf_counter() - t0) / repeats
 
     return {
-        "N": n_pulsars, "ndim": ndim,
+        "N": n_pulsars,
+        "ndim": ndim,
         "loglik_at_center": float(v),
-        "t_single_s": t_single, "t_batch_s": t_batch, "batch": batch,
+        "t_single_s": t_single,
+        "t_batch_s": t_batch,
+        "batch": batch,
         "t_per_particle_s": t_batch / batch,
     }
 
@@ -127,32 +141,43 @@ def main():
     os.makedirs(os.path.dirname(args.out), exist_ok=True)
 
     print("=" * 84)
-    print(f"Kalman likelihood microbenchmark (D=2 fixed-noise configs), batch={args.batch}")
+    print(
+        f"Kalman likelihood microbenchmark (D=2 fixed-noise configs), batch={args.batch}"
+    )
     print("=" * 84)
-    print(f"{'N':>4} {'ndim':>5} {'loglik@0':>14} {'t_single(ms)':>13} "
-          f"{'t_batch(ms)':>12} {'t/particle(ms)':>15}")
+    print(
+        f"{'N':>4} {'ndim':>5} {'loglik@0':>14} {'t_single(ms)':>13} "
+        f"{'t_batch(ms)':>12} {'t/particle(ms)':>15}"
+    )
 
     rows = []
     for N in args.N:
         cfg = os.path.join(DERIVED, f"ns_scal_fixed_N{N:02d}_D002_nl500_nd25_s42.ini")
         if not os.path.exists(cfg):
-            print(f"  (missing config for N={N}: {cfg}) -- run gen_scaling_configs.py --stage 1b")
+            print(
+                f"  (missing config for N={N}: {cfg}) -- run gen_scaling_configs.py --stage 1b"
+            )
             continue
         r = bench_one(cfg, batch=args.batch, repeats=args.repeats)
         rows.append(r)
-        print(f"{r['N']:>4} {r['ndim']:>5} {r['loglik_at_center']:>14.2f} "
-              f"{r['t_single_s']*1e3:>13.2f} {r['t_batch_s']*1e3:>12.2f} "
-              f"{r['t_per_particle_s']*1e3:>15.3f}")
+        print(
+            f"{r['N']:>4} {r['ndim']:>5} {r['loglik_at_center']:>14.2f} "
+            f"{r['t_single_s']*1e3:>13.2f} {r['t_batch_s']*1e3:>12.2f} "
+            f"{r['t_per_particle_s']*1e3:>15.3f}"
+        )
 
     if rows:
         with open(args.out, "w", newline="") as f:
             w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
-            w.writeheader(); w.writerows(rows)
+            w.writeheader()
+            w.writerows(rows)
         a1, b1 = _fit_powerlaw([r["N"] for r in rows], [r["t_single_s"] for r in rows])
         aB, bB = _fit_powerlaw([r["N"] for r in rows], [r["t_batch_s"] for r in rows])
         print("=" * 84)
-        print(f"fit: t_single(N) ~ {a1:.3g}*N^{b1:.2f} s   "
-              f"t_batch(N) ~ {aB:.3g}*N^{bB:.2f} s")
+        print(
+            f"fit: t_single(N) ~ {a1:.3g}*N^{b1:.2f} s   "
+            f"t_batch(N) ~ {aB:.3g}*N^{bB:.2f} s"
+        )
         print(f"CSV -> {args.out}")
 
 

--- a/workflows/ng15_sgwb_demo/scripts/ns_likelihood_microbench.py
+++ b/workflows/ng15_sgwb_demo/scripts/ns_likelihood_microbench.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+"""NS cost-scaling study — Stage 1b (revised): Kalman likelihood cost vs pulsar count N.
+
+Replaces running full nested sampling on MDC2 subsets (which is contaminated by the
+near-singular-covariance pathology — see notes/ns_numerical_hygiene.md) with a *direct
+microbenchmark* of the likelihood NS actually evaluates. We time
+``numpyro.infer.util.log_density(model)`` — i.e. one full Kalman-filter evaluation — at SANE
+parameters (all reparameterized latents = 0, the prior centre), so we never enter the
+pathological tails. This isolates the pure per-evaluation Kalman cost c(N), which is the
+quantity the combined cost model needs, cleanly and in seconds.
+
+We evaluate both a single draw and a batch of ``--batch`` draws (via ``jax.vmap``, mimicking
+the NS inner kernel's vmap over ``num_delete`` particles), reporting per-single and per-batch
+wall times. Fits c(N) ~ a * N^b.
+
+Run on GPU (the real venue) via SLURM, or on CPU for a quick check of small N:
+    JAX_PLATFORMS=cpu PYTHONPATH=<repo>/python python ns_likelihood_microbench.py --N 2 4 8
+"""
+import argparse
+import csv
+import logging
+import os
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+jax.config.update("jax_enable_x64", True)
+
+import configparser  # noqa: E402
+from numpyro.handlers import trace, seed  # noqa: E402
+from numpyro.infer.util import log_density  # noqa: E402
+
+from argus import workflow, utils, prior_models, io_manager  # noqa: E402
+from argus.bayesian_inference import numpyro_model  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+WORKFLOW = os.path.dirname(HERE)
+DERIVED = os.path.join(WORKFLOW, "outputs", "derived_configs")
+DEFAULT_OUT = os.path.join(WORKFLOW, "outputs", "scaling", "likelihood_cost_vs_N.csv")
+
+
+def _load_cfg(path):
+    cp = configparser.ConfigParser(interpolation=None)
+    cp.optionxform = str
+    cp.read(path)
+    return cp
+
+
+def bench_one(config_path, batch=25, repeats=20, warmup=3):
+    """Time one full-model log-density (Kalman) eval for the pulsar set in `config_path`."""
+    cp = _load_cfg(config_path)
+    # JaxKalmanFilter uses argus's global logger, which must be initialised first.
+    logger = io_manager.setup_single_logger(cp, output_dir=None, enable_file_logging=False)
+
+    pulsar_data, KF = workflow.setup_data_and_kalman_filter(
+        cp, logger, use_gw=True, signal_model="gwb")
+    n_pulsars = len(pulsar_data["metadata"])
+    efac, equad, sigma_p, gamma_p = utils.get_noise_parameters(cp)
+    prior_specs = prior_models.get_prior_model_specs(
+        cp, n_pulsars, sigma_p, gamma_p, efac, equad, mode="gwb")
+
+    def model():
+        numpyro_model(KF, prior_specs, n_pulsars)
+
+    # Latent sites (all reparameterized Normal(0,1)); evaluate at z=0 = prior centre (sane).
+    key = jax.random.PRNGKey(0)
+    tr = trace(seed(model, key)).get_trace()
+    latents = {name: jnp.zeros(jnp.shape(site["value"]))
+               for name, site in tr.items()
+               if site["type"] == "sample" and not site.get("is_observed", False)}
+    ndim = int(sum(int(np.prod(jnp.shape(v))) if jnp.shape(v) else 1
+                   for v in latents.values()))
+
+    def loglik(params):
+        lp, _ = log_density(model, (), {}, params)
+        return lp
+
+    f1 = jax.jit(loglik)
+    fB = jax.jit(jax.vmap(loglik))
+    batch_params = {k: jnp.broadcast_to(v, (batch,) + jnp.shape(v))
+                    for k, v in latents.items()}
+
+    # single-eval timing
+    v = f1(latents); v.block_until_ready()
+    for _ in range(warmup):
+        f1(latents).block_until_ready()
+    t0 = time.perf_counter()
+    for _ in range(repeats):
+        f1(latents).block_until_ready()
+    t_single = (time.perf_counter() - t0) / repeats
+
+    # batched-eval timing (vmap over `batch` particles, like NS's num_delete)
+    vb = fB(batch_params); vb.block_until_ready()
+    for _ in range(warmup):
+        fB(batch_params).block_until_ready()
+    t0 = time.perf_counter()
+    for _ in range(repeats):
+        fB(batch_params).block_until_ready()
+    t_batch = (time.perf_counter() - t0) / repeats
+
+    return {
+        "N": n_pulsars, "ndim": ndim,
+        "loglik_at_center": float(v),
+        "t_single_s": t_single, "t_batch_s": t_batch, "batch": batch,
+        "t_per_particle_s": t_batch / batch,
+    }
+
+
+def _fit_powerlaw(x, y):
+    x, y = np.asarray(x, float), np.asarray(y, float)
+    ok = (x > 0) & (y > 0)
+    if ok.sum() < 2:
+        return float("nan"), float("nan")
+    b, loga = np.polyfit(np.log(x[ok]), np.log(y[ok]), 1)
+    return float(np.exp(loga)), float(b)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--N", type=int, nargs="+", default=[2, 4, 8, 16, 32])
+    ap.add_argument("--batch", type=int, default=25)
+    ap.add_argument("--repeats", type=int, default=20)
+    ap.add_argument("--out", default=DEFAULT_OUT)
+    args = ap.parse_args()
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+
+    print("=" * 84)
+    print(f"Kalman likelihood microbenchmark (D=2 fixed-noise configs), batch={args.batch}")
+    print("=" * 84)
+    print(f"{'N':>4} {'ndim':>5} {'loglik@0':>14} {'t_single(ms)':>13} "
+          f"{'t_batch(ms)':>12} {'t/particle(ms)':>15}")
+
+    rows = []
+    for N in args.N:
+        cfg = os.path.join(DERIVED, f"ns_scal_fixed_N{N:02d}_D002_nl500_nd25_s42.ini")
+        if not os.path.exists(cfg):
+            print(f"  (missing config for N={N}: {cfg}) -- run gen_scaling_configs.py --stage 1b")
+            continue
+        r = bench_one(cfg, batch=args.batch, repeats=args.repeats)
+        rows.append(r)
+        print(f"{r['N']:>4} {r['ndim']:>5} {r['loglik_at_center']:>14.2f} "
+              f"{r['t_single_s']*1e3:>13.2f} {r['t_batch_s']*1e3:>12.2f} "
+              f"{r['t_per_particle_s']*1e3:>15.3f}")
+
+    if rows:
+        with open(args.out, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            w.writeheader(); w.writerows(rows)
+        a1, b1 = _fit_powerlaw([r["N"] for r in rows], [r["t_single_s"] for r in rows])
+        aB, bB = _fit_powerlaw([r["N"] for r in rows], [r["t_batch_s"] for r in rows])
+        print("=" * 84)
+        print(f"fit: t_single(N) ~ {a1:.3g}*N^{b1:.2f} s   "
+              f"t_batch(N) ~ {aB:.3g}*N^{bB:.2f} s")
+        print(f"CSV -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/ng15_sgwb_demo/scripts/ns_pathology_probe.py
+++ b/workflows/ng15_sgwb_demo/scripts/ns_pathology_probe.py
@@ -14,6 +14,7 @@ Usage (CPU, fast for the D=2 fixed-noise configs):
 
 Exit 0 if max|logL| stays within --sane-cap (pathology absent/guarded), else 1.
 """
+
 import argparse
 import itertools
 import os
@@ -36,13 +37,17 @@ def build_loglik(config_path):
     cp = configparser.ConfigParser(interpolation=None)
     cp.optionxform = str
     cp.read(config_path)
-    logger = io_manager.setup_single_logger(cp, output_dir=None, enable_file_logging=False)
+    logger = io_manager.setup_single_logger(
+        cp, output_dir=None, enable_file_logging=False
+    )
     pulsar_data, KF = workflow.setup_data_and_kalman_filter(
-        cp, logger, use_gw=True, signal_model="gwb")
+        cp, logger, use_gw=True, signal_model="gwb"
+    )
     n_pulsars = len(pulsar_data["metadata"])
     efac, equad, sigma_p, gamma_p = utils.get_noise_parameters(cp)
     prior_specs = prior_models.get_prior_model_specs(
-        cp, n_pulsars, sigma_p, gamma_p, efac, equad, mode="gwb")
+        cp, n_pulsars, sigma_p, gamma_p, efac, equad, mode="gwb"
+    )
 
     def model():
         numpyro_model(KF, prior_specs, n_pulsars)
@@ -51,14 +56,15 @@ def build_loglik(config_path):
     names, shapes = [], []
     for name, site in tr.items():
         if site["type"] == "sample" and not site.get("is_observed", False):
-            names.append(name); shapes.append(jnp.shape(site["value"]))
+            names.append(name)
+            shapes.append(jnp.shape(site["value"]))
     sizes = [int(np.prod(s)) if s else 1 for s in shapes]
     ndim = int(sum(sizes))
 
     def unpack(z):
         out, off = {}, 0
         for nm, sh, sz in zip(names, shapes, sizes):
-            out[nm] = z[off] if sh == () else z[off:off+sz].reshape(sh)
+            out[nm] = z[off] if sh == () else z[off : off + sz].reshape(sh)
             off += sz
         return out
 
@@ -72,7 +78,9 @@ def build_loglik(config_path):
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--config", required=True)
-    ap.add_argument("--span", type=float, default=8.0, help="scan each latent in [-span, span]")
+    ap.add_argument(
+        "--span", type=float, default=8.0, help="scan each latent in [-span, span]"
+    )
     ap.add_argument("--grid", type=int, default=41)
     ap.add_argument("--sane-cap", type=float, default=1e6)
     args = ap.parse_args()
@@ -84,17 +92,22 @@ def main():
     axis = np.linspace(-args.span, args.span, args.grid)
     worst, worst_z = -np.inf, None
     for zi, zj in itertools.product(axis, axis):
-        z = np.zeros(ndim); z[0] = zi
+        z = np.zeros(ndim)
+        z[0] = zi
         if ndim > 1:
             z[1] = zj
         v = float(loglik(jnp.asarray(z)))
         if np.isfinite(v) and v > worst:
             worst, worst_z = v, (zi, zj)
-    print(f"config N={N} ndim={ndim}: max logL over |z|<= {args.span} grid = {worst:.4g} "
-          f"at z[:2]={worst_z}")
+    print(
+        f"config N={N} ndim={ndim}: max logL over |z|<= {args.span} grid = {worst:.4g} "
+        f"at z[:2]={worst_z}"
+    )
     ok = abs(worst) < args.sane_cap
-    print(f"PATHOLOGY {'ABSENT (bounded)' if ok else 'PRESENT (spurious huge logL)'} "
-          f"[sane cap {args.sane_cap:g}]")
+    print(
+        f"PATHOLOGY {'ABSENT (bounded)' if ok else 'PRESENT (spurious huge logL)'} "
+        f"[sane cap {args.sane_cap:g}]"
+    )
     raise SystemExit(0 if ok else 1)
 
 

--- a/workflows/ng15_sgwb_demo/scripts/ns_pathology_probe.py
+++ b/workflows/ng15_sgwb_demo/scripts/ns_pathology_probe.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""Reproduce / regression-test the NS near-singular-covariance pathology.
+
+Nested sampling explores the full prior, reaching latent-tail parameter values where the
+Kalman innovation covariance goes near-singular and `_log_likelihood` returns a spurious
+*huge positive* value (slogdet -> -inf, quadratic stays finite). This probe scans the free
+latents over a box (default |z| <= 8, i.e. beyond the 6-sigma NS guard) and reports the max
+log-likelihood encountered. A sane likelihood is O(1e4) here; anything >> that is the
+pathology.
+
+Usage (CPU, fast for the D=2 fixed-noise configs):
+    JAX_PLATFORMS=cpu PYTHONPATH=<repo>/python python ns_pathology_probe.py \
+        --config <derived_configs/ns_scal_fixed_N04_...ini> --span 8 --grid 41
+
+Exit 0 if max|logL| stays within --sane-cap (pathology absent/guarded), else 1.
+"""
+import argparse
+import itertools
+import os
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+jax.config.update("jax_enable_x64", True)
+
+import configparser  # noqa: E402
+from numpyro.handlers import trace, seed  # noqa: E402
+from numpyro.infer.util import log_density  # noqa: E402
+
+from argus import workflow, utils, prior_models, io_manager  # noqa: E402
+from argus.bayesian_inference import numpyro_model  # noqa: E402
+
+
+def build_loglik(config_path):
+    cp = configparser.ConfigParser(interpolation=None)
+    cp.optionxform = str
+    cp.read(config_path)
+    logger = io_manager.setup_single_logger(cp, output_dir=None, enable_file_logging=False)
+    pulsar_data, KF = workflow.setup_data_and_kalman_filter(
+        cp, logger, use_gw=True, signal_model="gwb")
+    n_pulsars = len(pulsar_data["metadata"])
+    efac, equad, sigma_p, gamma_p = utils.get_noise_parameters(cp)
+    prior_specs = prior_models.get_prior_model_specs(
+        cp, n_pulsars, sigma_p, gamma_p, efac, equad, mode="gwb")
+
+    def model():
+        numpyro_model(KF, prior_specs, n_pulsars)
+
+    tr = trace(seed(model, jax.random.PRNGKey(0))).get_trace()
+    names, shapes = [], []
+    for name, site in tr.items():
+        if site["type"] == "sample" and not site.get("is_observed", False):
+            names.append(name); shapes.append(jnp.shape(site["value"]))
+    sizes = [int(np.prod(s)) if s else 1 for s in shapes]
+    ndim = int(sum(sizes))
+
+    def unpack(z):
+        out, off = {}, 0
+        for nm, sh, sz in zip(names, shapes, sizes):
+            out[nm] = z[off] if sh == () else z[off:off+sz].reshape(sh)
+            off += sz
+        return out
+
+    def loglik(z):
+        lp, _ = log_density(model, (), {}, unpack(z))
+        return lp  # log joint; prior is unit-normal (constant scale), fine for magnitude probe
+
+    return jax.jit(loglik), ndim, n_pulsars
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--span", type=float, default=8.0, help="scan each latent in [-span, span]")
+    ap.add_argument("--grid", type=int, default=41)
+    ap.add_argument("--sane-cap", type=float, default=1e6)
+    args = ap.parse_args()
+
+    loglik, ndim, N = build_loglik(args.config)
+    if ndim > 2:
+        # Only scan the first 2 dims on a grid; hold the rest at 0 (enough to expose the mode).
+        print(f"[warn] ndim={ndim} > 2; scanning first 2 latents, rest fixed at 0")
+    axis = np.linspace(-args.span, args.span, args.grid)
+    worst, worst_z = -np.inf, None
+    for zi, zj in itertools.product(axis, axis):
+        z = np.zeros(ndim); z[0] = zi
+        if ndim > 1:
+            z[1] = zj
+        v = float(loglik(jnp.asarray(z)))
+        if np.isfinite(v) and v > worst:
+            worst, worst_z = v, (zi, zj)
+    print(f"config N={N} ndim={ndim}: max logL over |z|<= {args.span} grid = {worst:.4g} "
+          f"at z[:2]={worst_z}")
+    ok = abs(worst) < args.sane_cap
+    print(f"PATHOLOGY {'ABSENT (bounded)' if ok else 'PRESENT (spurious huge logL)'} "
+          f"[sane cap {args.sane_cap:g}]")
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/ng15_sgwb_demo/scripts/ns_scaling_analyze.py
+++ b/workflows/ng15_sgwb_demo/scripts/ns_scaling_analyze.py
@@ -18,6 +18,7 @@ Outputs: outputs/scaling/scaling_combined.csv, PNG plots, and a printed verdict 
 Run:
     python workflows/ng15_sgwb_demo/scripts/ns_scaling_analyze.py
 """
+
 import argparse
 import csv
 import glob
@@ -69,7 +70,9 @@ def load_stage1a(path):
 def load_evidence_jsons(outputs):
     """Load every *_evidence.json under outputs/, keeping those with scaling metadata."""
     rows = []
-    for path in glob.glob(os.path.join(outputs, "**", "*_evidence.json"), recursive=True):
+    for path in glob.glob(
+        os.path.join(outputs, "**", "*_evidence.json"), recursive=True
+    ):
         try:
             with open(path) as f:
                 d = json.load(f)
@@ -104,15 +107,18 @@ def main():
         dims = [r["d"] for r in s1a]
         a_s, b_s = _fit_powerlaw(dims, [r["n_steps"] for r in s1a])
         n_steps_of_D = (a_s, b_s)
-        print(f"\n[Stage 1a] pure-dimension (likelihood-free), {len(s1a)} points d={dims}")
+        print(
+            f"\n[Stage 1a] pure-dimension (likelihood-free), {len(s1a)} points d={dims}"
+        )
         print(f"  n_steps(D) ~ {a_s:.3g} * D^{b_s:.2f}")
         # Accuracy-vs-D: flag the smallest D where |err| exceeds 3*logZ_err.
-        biased = [r["d"] for r in s1a
-                  if r["abs_err"] > max(3 * r["logZ_err"], 0.5)]
+        biased = [r["d"] for r in s1a if r["abs_err"] > max(3 * r["logZ_err"], 0.5)]
         if biased:
-            print(f"  logZ ACCURACY breaks (|err|>3σ) from D={min(biased)} upward "
-                  f"at num_live={s1a[0]['num_live']}, num_delete={s1a[0]['num_delete']} "
-                  f"-> evidence bias grows with dimension (see Stage 3 for the tuning fix).")
+            print(
+                f"  logZ ACCURACY breaks (|err|>3σ) from D={min(biased)} upward "
+                f"at num_live={s1a[0]['num_live']}, num_delete={s1a[0]['num_delete']} "
+                f"-> evidence bias grows with dimension (see Stage 3 for the tuning fix)."
+            )
         else:
             print("  logZ accuracy holds across all tested D (no bias detected).")
 
@@ -124,15 +130,19 @@ def main():
     c_of_N = (float("nan"), float("nan"))
     if s1b:
         Ns = [r["n_pulsars"] for r in s1b]
-        cs = [r["runtime_s"] / max(1, r["n_steps"] * r.get("num_inner_steps", 1))
-              for r in s1b]
+        cs = [
+            r["runtime_s"] / max(1, r["n_steps"] * r.get("num_inner_steps", 1))
+            for r in s1b
+        ]
         a_c, b_c = _fit_powerlaw(Ns, cs)
         c_of_N = (a_c, b_c)
         print(f"\n[Stage 1b] Kalman cost at D=2, N={Ns}")
         for r, c in zip(s1b, cs):
-            print(f"  N={r['n_pulsars']:>3}  {r['n_steps']:>6} steps x "
-                  f"{r.get('num_inner_steps','?')} inner  {r['runtime_s']:>8.1f}s  "
-                  f"{c*1e6:>8.2f} us/(step·inner)")
+            print(
+                f"  N={r['n_pulsars']:>3}  {r['n_steps']:>6} steps x "
+                f"{r.get('num_inner_steps','?')} inner  {r['runtime_s']:>8.1f}s  "
+                f"{c*1e6:>8.2f} us/(step·inner)"
+            )
         print(f"  c(N) ~ {a_c:.3g} * N^{b_c:.2f} s   (per NS-step·inner-step)")
 
     # --- Coupled points (Stage 2) --------------------------------------------------------
@@ -140,9 +150,11 @@ def main():
     if s2:
         print(f"\n[Stage 2] coupled real-model points:")
         for r in s2:
-            print(f"  N={r['n_pulsars']:>3} D={r['ndim']:>3}  {r['n_steps']:>6} steps  "
-                  f"{r['runtime_s']:>9.1f}s  logZ={r['log_Z_mean']:.2f}"
-                  f"+/-{r['log_Z_uncert']:.2f}")
+            print(
+                f"  N={r['n_pulsars']:>3} D={r['ndim']:>3}  {r['n_steps']:>6} steps  "
+                f"{r['runtime_s']:>9.1f}s  logZ={r['log_Z_mean']:.2f}"
+                f"+/-{r['log_Z_uncert']:.2f}"
+            )
 
     # --- Combined cost model + extrapolation ---------------------------------------------
     # T(N,D) = n_steps(D) * num_inner_steps(D) * c(N), with num_inner_steps = INNER_MULT*D
@@ -151,52 +163,91 @@ def main():
     a_c, b_c = c_of_N
     print("\n" + "=" * 88)
     if not (np.isnan(a_s) or np.isnan(a_c)):
+
         def T(N, D):
-            n_steps = a_s * D ** b_s
+            n_steps = a_s * D**b_s
             nis = max(5, INNER_MULT * D)
-            c = a_c * N ** b_c
+            c = a_c * N**b_c
             return n_steps * nis * c
-        for (N, D, tag) in [(6, 30, "T3.4 few-pulsar"),
-                            (16, 70, "mid"),
-                            (NG15_N, NG15_D, "NG15 full-PTA")]:
+
+        for N, D, tag in [
+            (6, 30, "T3.4 few-pulsar"),
+            (16, 70, "mid"),
+            (NG15_N, NG15_D, "NG15 full-PTA"),
+        ]:
             t = T(N, D)
-            print(f"  extrapolated T(N={N}, D={D}) [{tag}] "
-                  f"= {t:.3g}s = {t/3600:.2f} h = {t/DAY_S:.2f} d")
+            print(
+                f"  extrapolated T(N={N}, D={D}) [{tag}] "
+                f"= {t:.3g}s = {t/3600:.2f} h = {t/DAY_S:.2f} d"
+            )
         t_full = T(NG15_N, NG15_D)
         if t_full <= 2 * DAY_S:
             verdict = "GO (full-PTA evidence run projected under ~2 days/A100)"
         elif t_full <= WEEK_S:
             verdict = "GO/CONDITIONAL (projected within the ~1-week/A100 bar)"
         else:
-            verdict = ("CONDITIONAL/KILL (projected beyond ~1 week/A100 — restrict "
-                       "dimension/pulsars or use NUTS+stepping-stone for evidence)")
+            verdict = (
+                "CONDITIONAL/KILL (projected beyond ~1 week/A100 — restrict "
+                "dimension/pulsars or use NUTS+stepping-stone for evidence)"
+            )
         print(f"\n  RUNTIME VERDICT: {verdict}")
     else:
         print("  (need both Stage 1a and Stage 1b results to build the cost model)")
-    print("  NOTE: accuracy is a separate gate from runtime — a fast run with biased logZ")
-    print("        is useless for a Bayes factor. See the Stage 1a accuracy line above.")
+    print(
+        "  NOTE: accuracy is a separate gate from runtime — a fast run with biased logZ"
+    )
+    print(
+        "        is useless for a Bayes factor. See the Stage 1a accuracy line above."
+    )
     print("=" * 88)
 
     # --- Persist combined table ----------------------------------------------------------
     combined = os.path.join(SCALING, "scaling_combined.csv")
-    fields = ["source", "output_id", "N", "D", "n_steps", "runtime_s",
-              "num_live", "num_delete", "log_Z_mean", "log_Z_uncert"]
+    fields = [
+        "source",
+        "output_id",
+        "N",
+        "D",
+        "n_steps",
+        "runtime_s",
+        "num_live",
+        "num_delete",
+        "log_Z_mean",
+        "log_Z_uncert",
+    ]
     with open(combined, "w", newline="") as f:
         w = csv.DictWriter(f, fieldnames=fields)
         w.writeheader()
         for r in s1a:
-            w.writerow({"source": "1a_analytic", "output_id": f"gauss_d{r['d']}",
-                        "N": "", "D": r["d"], "n_steps": r["n_steps"],
-                        "runtime_s": r["wall_s"], "num_live": r["num_live"],
-                        "num_delete": r["num_delete"], "log_Z_mean": r["logZ_est"],
-                        "log_Z_uncert": r["logZ_err"]})
+            w.writerow(
+                {
+                    "source": "1a_analytic",
+                    "output_id": f"gauss_d{r['d']}",
+                    "N": "",
+                    "D": r["d"],
+                    "n_steps": r["n_steps"],
+                    "runtime_s": r["wall_s"],
+                    "num_live": r["num_live"],
+                    "num_delete": r["num_delete"],
+                    "log_Z_mean": r["logZ_est"],
+                    "log_Z_uncert": r["logZ_err"],
+                }
+            )
         for r in ev:
-            w.writerow({"source": "gpu_run", "output_id": r["output_id"],
-                        "N": r.get("n_pulsars", ""), "D": r.get("ndim", ""),
-                        "n_steps": r.get("n_steps", ""), "runtime_s": r.get("runtime_s", ""),
-                        "num_live": r.get("n_live", ""), "num_delete": r.get("num_delete", ""),
-                        "log_Z_mean": r.get("log_Z_mean", ""),
-                        "log_Z_uncert": r.get("log_Z_uncert", "")})
+            w.writerow(
+                {
+                    "source": "gpu_run",
+                    "output_id": r["output_id"],
+                    "N": r.get("n_pulsars", ""),
+                    "D": r.get("ndim", ""),
+                    "n_steps": r.get("n_steps", ""),
+                    "runtime_s": r.get("runtime_s", ""),
+                    "num_live": r.get("n_live", ""),
+                    "num_delete": r.get("num_delete", ""),
+                    "log_Z_mean": r.get("log_Z_mean", ""),
+                    "log_Z_uncert": r.get("log_Z_uncert", ""),
+                }
+            )
     print(f"combined table -> {combined}")
 
     if not args.no_plots:
@@ -206,6 +257,7 @@ def main():
 def _make_plots(s1a, s1b, s2):
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
     except ImportError:
@@ -216,13 +268,22 @@ def _make_plots(s1a, s1b, s2):
         fig, axes = plt.subplots(1, 3, figsize=(15, 4))
         d = [r["d"] for r in s1a]
         axes[0].loglog(d, [r["n_steps"] for r in s1a], "o-")
-        axes[0].set(xlabel="dimension D", ylabel="NS steps", title="Stage 1a: n_steps(D)")
+        axes[0].set(
+            xlabel="dimension D", ylabel="NS steps", title="Stage 1a: n_steps(D)"
+        )
         axes[1].loglog(d, [r["wall_s"] for r in s1a], "o-", color="C1")
         axes[1].set(xlabel="dimension D", ylabel="wall (s)", title="Stage 1a: wall(D)")
-        axes[2].semilogx(d, [r["abs_err"] for r in s1a], "o-", color="C3", label="|logZ err|")
-        axes[2].semilogx(d, [3 * r["logZ_err"] for r in s1a], "s--", color="k", label="3σ")
-        axes[2].set(xlabel="dimension D", ylabel="logZ error",
-                    title="Stage 1a: evidence accuracy")
+        axes[2].semilogx(
+            d, [r["abs_err"] for r in s1a], "o-", color="C3", label="|logZ err|"
+        )
+        axes[2].semilogx(
+            d, [3 * r["logZ_err"] for r in s1a], "s--", color="k", label="3σ"
+        )
+        axes[2].set(
+            xlabel="dimension D",
+            ylabel="logZ error",
+            title="Stage 1a: evidence accuracy",
+        )
         axes[2].legend()
         fig.tight_layout()
         p = os.path.join(SCALING, "stage1a_dimension.png")
@@ -233,8 +294,11 @@ def _make_plots(s1a, s1b, s2):
         fig, ax = plt.subplots(figsize=(6, 4))
         N = [r["n_pulsars"] for r in s1b]
         ax.loglog(N, [r["runtime_s"] / max(1, r["n_steps"]) * 1e3 for r in s1b], "o-")
-        ax.set(xlabel="N pulsars", ylabel="ms / NS step (D=2)",
-               title="Stage 1b: Kalman likelihood cost vs N")
+        ax.set(
+            xlabel="N pulsars",
+            ylabel="ms / NS step (D=2)",
+            title="Stage 1b: Kalman likelihood cost vs N",
+        )
         fig.tight_layout()
         p = os.path.join(SCALING, "stage1b_pulsars.png")
         fig.savefig(p, dpi=110)

--- a/workflows/ng15_sgwb_demo/scripts/ns_scaling_analyze.py
+++ b/workflows/ng15_sgwb_demo/scripts/ns_scaling_analyze.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python
+"""NS cost-scaling study — synthesis, extrapolation, and verdict.
+
+Aggregates every stage of the study into one tidy table, fits the two cost axes, builds a
+combined cost model T(N, D) ~ n_steps(D) * t_per_step(N, D), extrapolates to full-PTA scale
+(NG15: N~67, D~274), and prints a GO / CONDITIONAL / KILL verdict.
+
+Inputs (whatever exists — the script degrades gracefully):
+  * Stage 1a  — outputs/scaling/dimension_scaling.csv (pure-dimension, likelihood-free):
+                gives n_steps(D), wall(D), and the logZ-accuracy-vs-D trend.
+  * Stages 1b/2/3 — outputs/<output_id>/<output_id>_evidence.json, each now carrying the
+                Stage-0 metadata (runtime_s, n_steps, ndim, n_live, num_delete, n_pulsars,
+                log_Z_mean, log_Z_uncert). Stage 1b (D=2, varying N) gives t_per_step(N);
+                Stage 2 (coupled) validates the combined model; Stage 3 gives knob constants.
+
+Outputs: outputs/scaling/scaling_combined.csv, PNG plots, and a printed verdict block.
+
+Run:
+    python workflows/ng15_sgwb_demo/scripts/ns_scaling_analyze.py
+"""
+import argparse
+import csv
+import glob
+import json
+import os
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+WORKFLOW = os.path.dirname(HERE)
+OUTPUTS = os.path.join(WORKFLOW, "outputs")
+SCALING = os.path.join(OUTPUTS, "scaling")
+
+# Full-PTA extrapolation target (NG15-scale, all noise free): D = 4N + 6.
+NG15_N = 67
+NG15_D = 4 * NG15_N + 6
+# Accuracy-preserving inner-step policy (matches gen_scaling_configs.INNER_MULT).
+INNER_MULT = 6
+# Tractability bar agreed with the user: a full-PTA evidence run should finish within about
+# a week on one A100 (a day or two is ideal for dev iteration).
+WEEK_S = 7 * 24 * 3600.0
+DAY_S = 24 * 3600.0
+
+
+def _fit_powerlaw(x, y):
+    x, y = np.asarray(x, float), np.asarray(y, float)
+    ok = (x > 0) & (y > 0)
+    if ok.sum() < 2:
+        return float("nan"), float("nan")
+    b, loga = np.polyfit(np.log(x[ok]), np.log(y[ok]), 1)
+    return float(np.exp(loga)), float(b)
+
+
+def load_stage1a(path):
+    if not os.path.exists(path):
+        return []
+    with open(path) as f:
+        rows = list(csv.DictReader(f))
+    for r in rows:
+        for k in ("d", "n_steps", "num_inner_steps", "num_live", "num_delete"):
+            if k in r and r[k] != "":
+                r[k] = int(float(r[k]))
+        for k in ("logZ_true", "logZ_est", "logZ_err", "abs_err", "wall_s"):
+            if k in r and r[k] != "":
+                r[k] = float(r[k])
+    return rows
+
+
+def load_evidence_jsons(outputs):
+    """Load every *_evidence.json under outputs/, keeping those with scaling metadata."""
+    rows = []
+    for path in glob.glob(os.path.join(outputs, "**", "*_evidence.json"), recursive=True):
+        try:
+            with open(path) as f:
+                d = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if "n_steps" not in d or "ndim" not in d:
+            continue  # pre-instrumentation evidence.json (no timing) — skip
+        d["_path"] = path
+        d["output_id"] = os.path.basename(path).replace("_evidence.json", "")
+        rows.append(d)
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--stage1a", default=os.path.join(SCALING, "dimension_scaling.csv"))
+    ap.add_argument("--outputs", default=OUTPUTS)
+    ap.add_argument("--no-plots", action="store_true")
+    args = ap.parse_args()
+    os.makedirs(SCALING, exist_ok=True)
+
+    s1a = load_stage1a(args.stage1a)
+    ev = load_evidence_jsons(args.outputs)
+
+    print("=" * 88)
+    print("NS cost-scaling synthesis")
+    print("=" * 88)
+
+    # --- Axis 1: pure-dimension scaling (Stage 1a) ---------------------------------------
+    n_steps_of_D = (float("nan"), float("nan"))
+    if s1a:
+        dims = [r["d"] for r in s1a]
+        a_s, b_s = _fit_powerlaw(dims, [r["n_steps"] for r in s1a])
+        n_steps_of_D = (a_s, b_s)
+        print(f"\n[Stage 1a] pure-dimension (likelihood-free), {len(s1a)} points d={dims}")
+        print(f"  n_steps(D) ~ {a_s:.3g} * D^{b_s:.2f}")
+        # Accuracy-vs-D: flag the smallest D where |err| exceeds 3*logZ_err.
+        biased = [r["d"] for r in s1a
+                  if r["abs_err"] > max(3 * r["logZ_err"], 0.5)]
+        if biased:
+            print(f"  logZ ACCURACY breaks (|err|>3σ) from D={min(biased)} upward "
+                  f"at num_live={s1a[0]['num_live']}, num_delete={s1a[0]['num_delete']} "
+                  f"-> evidence bias grows with dimension (see Stage 3 for the tuning fix).")
+        else:
+            print("  logZ accuracy holds across all tested D (no bias detected).")
+
+    # --- Axis 2: per (NS-step * inner-step) cost vs N (Stage 1b, D=2) ---------------------
+    # Isolate the Kalman-eval cost c(N) = wall / (n_steps * num_inner_steps). Dividing out
+    # BOTH n_steps and num_inner_steps leaves the cost of one inner slice iteration, which is
+    # what actually carries the O(N) likelihood work — so c(N) is directly reusable at any D.
+    s1b = sorted([r for r in ev if r.get("ndim") == 2], key=lambda r: r["n_pulsars"])
+    c_of_N = (float("nan"), float("nan"))
+    if s1b:
+        Ns = [r["n_pulsars"] for r in s1b]
+        cs = [r["runtime_s"] / max(1, r["n_steps"] * r.get("num_inner_steps", 1))
+              for r in s1b]
+        a_c, b_c = _fit_powerlaw(Ns, cs)
+        c_of_N = (a_c, b_c)
+        print(f"\n[Stage 1b] Kalman cost at D=2, N={Ns}")
+        for r, c in zip(s1b, cs):
+            print(f"  N={r['n_pulsars']:>3}  {r['n_steps']:>6} steps x "
+                  f"{r.get('num_inner_steps','?')} inner  {r['runtime_s']:>8.1f}s  "
+                  f"{c*1e6:>8.2f} us/(step·inner)")
+        print(f"  c(N) ~ {a_c:.3g} * N^{b_c:.2f} s   (per NS-step·inner-step)")
+
+    # --- Coupled points (Stage 2) --------------------------------------------------------
+    s2 = sorted([r for r in ev if r.get("ndim", 0) > 2], key=lambda r: r["ndim"])
+    if s2:
+        print(f"\n[Stage 2] coupled real-model points:")
+        for r in s2:
+            print(f"  N={r['n_pulsars']:>3} D={r['ndim']:>3}  {r['n_steps']:>6} steps  "
+                  f"{r['runtime_s']:>9.1f}s  logZ={r['log_Z_mean']:.2f}"
+                  f"+/-{r['log_Z_uncert']:.2f}")
+
+    # --- Combined cost model + extrapolation ---------------------------------------------
+    # T(N,D) = n_steps(D) * num_inner_steps(D) * c(N), with num_inner_steps = INNER_MULT*D
+    # (the accuracy-preserving policy from Stage 1a). All three factors measured separately.
+    a_s, b_s = n_steps_of_D
+    a_c, b_c = c_of_N
+    print("\n" + "=" * 88)
+    if not (np.isnan(a_s) or np.isnan(a_c)):
+        def T(N, D):
+            n_steps = a_s * D ** b_s
+            nis = max(5, INNER_MULT * D)
+            c = a_c * N ** b_c
+            return n_steps * nis * c
+        for (N, D, tag) in [(6, 30, "T3.4 few-pulsar"),
+                            (16, 70, "mid"),
+                            (NG15_N, NG15_D, "NG15 full-PTA")]:
+            t = T(N, D)
+            print(f"  extrapolated T(N={N}, D={D}) [{tag}] "
+                  f"= {t:.3g}s = {t/3600:.2f} h = {t/DAY_S:.2f} d")
+        t_full = T(NG15_N, NG15_D)
+        if t_full <= 2 * DAY_S:
+            verdict = "GO (full-PTA evidence run projected under ~2 days/A100)"
+        elif t_full <= WEEK_S:
+            verdict = "GO/CONDITIONAL (projected within the ~1-week/A100 bar)"
+        else:
+            verdict = ("CONDITIONAL/KILL (projected beyond ~1 week/A100 — restrict "
+                       "dimension/pulsars or use NUTS+stepping-stone for evidence)")
+        print(f"\n  RUNTIME VERDICT: {verdict}")
+    else:
+        print("  (need both Stage 1a and Stage 1b results to build the cost model)")
+    print("  NOTE: accuracy is a separate gate from runtime — a fast run with biased logZ")
+    print("        is useless for a Bayes factor. See the Stage 1a accuracy line above.")
+    print("=" * 88)
+
+    # --- Persist combined table ----------------------------------------------------------
+    combined = os.path.join(SCALING, "scaling_combined.csv")
+    fields = ["source", "output_id", "N", "D", "n_steps", "runtime_s",
+              "num_live", "num_delete", "log_Z_mean", "log_Z_uncert"]
+    with open(combined, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        for r in s1a:
+            w.writerow({"source": "1a_analytic", "output_id": f"gauss_d{r['d']}",
+                        "N": "", "D": r["d"], "n_steps": r["n_steps"],
+                        "runtime_s": r["wall_s"], "num_live": r["num_live"],
+                        "num_delete": r["num_delete"], "log_Z_mean": r["logZ_est"],
+                        "log_Z_uncert": r["logZ_err"]})
+        for r in ev:
+            w.writerow({"source": "gpu_run", "output_id": r["output_id"],
+                        "N": r.get("n_pulsars", ""), "D": r.get("ndim", ""),
+                        "n_steps": r.get("n_steps", ""), "runtime_s": r.get("runtime_s", ""),
+                        "num_live": r.get("n_live", ""), "num_delete": r.get("num_delete", ""),
+                        "log_Z_mean": r.get("log_Z_mean", ""),
+                        "log_Z_uncert": r.get("log_Z_uncert", "")})
+    print(f"combined table -> {combined}")
+
+    if not args.no_plots:
+        _make_plots(s1a, s1b, s2)
+
+
+def _make_plots(s1a, s1b, s2):
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("matplotlib unavailable; skipping plots")
+        return
+
+    if s1a:
+        fig, axes = plt.subplots(1, 3, figsize=(15, 4))
+        d = [r["d"] for r in s1a]
+        axes[0].loglog(d, [r["n_steps"] for r in s1a], "o-")
+        axes[0].set(xlabel="dimension D", ylabel="NS steps", title="Stage 1a: n_steps(D)")
+        axes[1].loglog(d, [r["wall_s"] for r in s1a], "o-", color="C1")
+        axes[1].set(xlabel="dimension D", ylabel="wall (s)", title="Stage 1a: wall(D)")
+        axes[2].semilogx(d, [r["abs_err"] for r in s1a], "o-", color="C3", label="|logZ err|")
+        axes[2].semilogx(d, [3 * r["logZ_err"] for r in s1a], "s--", color="k", label="3σ")
+        axes[2].set(xlabel="dimension D", ylabel="logZ error",
+                    title="Stage 1a: evidence accuracy")
+        axes[2].legend()
+        fig.tight_layout()
+        p = os.path.join(SCALING, "stage1a_dimension.png")
+        fig.savefig(p, dpi=110)
+        print(f"plot -> {p}")
+
+    if s1b:
+        fig, ax = plt.subplots(figsize=(6, 4))
+        N = [r["n_pulsars"] for r in s1b]
+        ax.loglog(N, [r["runtime_s"] / max(1, r["n_steps"]) * 1e3 for r in s1b], "o-")
+        ax.set(xlabel="N pulsars", ylabel="ms / NS step (D=2)",
+               title="Stage 1b: Kalman likelihood cost vs N")
+        fig.tight_layout()
+        p = os.path.join(SCALING, "stage1b_pulsars.png")
+        fig.savefig(p, dpi=110)
+        print(f"plot -> {p}")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/ng15_sgwb_demo/scripts/ns_scaling_dimension.py
+++ b/workflows/ng15_sgwb_demo/scripts/ns_scaling_dimension.py
@@ -30,6 +30,7 @@ Exit code 0 iff every dimension's recovered logZ agrees with the closed form wit
 tolerance (|logZ_est - logZ_true| < max(3*logZ_err, ATOL)); otherwise 1 (evidence became
 unreliable at some dimension — itself a study finding).
 """
+
 import argparse
 import csv
 import math
@@ -51,8 +52,18 @@ DEFAULT_OUT = os.path.join(
 )
 
 
-def run_dim(d, half_width=10.0, num_live=500, num_delete=25, num_inner_steps=None,
-            inner_mult=None, seed=0, dlogz=-5.0, max_steps=200000, kernel="nss"):
+def run_dim(
+    d,
+    half_width=10.0,
+    num_live=500,
+    num_delete=25,
+    num_inner_steps=None,
+    inner_mult=None,
+    seed=0,
+    dlogz=-5.0,
+    max_steps=200000,
+    kernel="nss",
+):
     """Run NS on the d-dim analytic Gaussian; return (logZ_true, res).
 
     Mirrors ``blackjax_ns_analytic_check.run_dim`` (same target, same known logZ) but with
@@ -110,29 +121,46 @@ def _fit_powerlaw(x, y):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--dims", type=int, nargs="+",
-                        default=[2, 5, 15, 30, 60, 120, 270])
+    parser.add_argument(
+        "--dims", type=int, nargs="+", default=[2, 5, 15, 30, 60, 120, 270]
+    )
     parser.add_argument("--num-live", type=int, default=500)
     parser.add_argument("--num-delete", type=int, default=25)
-    parser.add_argument("--num-inner-steps", type=int, default=None,
-                        help="Fixed inner-step count; default engine's max(5, 2*d).")
-    parser.add_argument("--inner-mult", type=float, default=None,
-                        help="Set num_inner_steps = inner_mult*d (overrides --num-inner-steps). "
-                             "Stage-1a diagnostic: ~6 recovers logZ accuracy at high d.")
+    parser.add_argument(
+        "--num-inner-steps",
+        type=int,
+        default=None,
+        help="Fixed inner-step count; default engine's max(5, 2*d).",
+    )
+    parser.add_argument(
+        "--inner-mult",
+        type=float,
+        default=None,
+        help="Set num_inner_steps = inner_mult*d (overrides --num-inner-steps). "
+        "Stage-1a diagnostic: ~6 recovers logZ accuracy at high d.",
+    )
     parser.add_argument("--dlogz", type=float, default=-5.0)
     parser.add_argument("--atol", type=float, default=0.5)
-    parser.add_argument("--out", default=os.path.join(DEFAULT_OUT, "dimension_scaling.csv"))
+    parser.add_argument(
+        "--out", default=os.path.join(DEFAULT_OUT, "dimension_scaling.csv")
+    )
     args = parser.parse_args()
 
     os.makedirs(os.path.dirname(args.out), exist_ok=True)
 
     print("=" * 92)
-    print("NS scaling Stage 1a: pure-dimension scaling (analytic Gaussian, likelihood-free)")
-    print(f"num_live={args.num_live}  num_delete={args.num_delete}  "
-          f"num_inner_steps={args.num_inner_steps or 'max(5,2d)'}  dlogz={args.dlogz}")
+    print(
+        "NS scaling Stage 1a: pure-dimension scaling (analytic Gaussian, likelihood-free)"
+    )
+    print(
+        f"num_live={args.num_live}  num_delete={args.num_delete}  "
+        f"num_inner_steps={args.num_inner_steps or 'max(5,2d)'}  dlogz={args.dlogz}"
+    )
     print("=" * 92)
-    header = (f"{'d':>5} {'logZ_true':>12} {'logZ_est':>12} {'logZ_err':>10} "
-              f"{'|err|':>8} {'inner':>6} {'steps':>8} {'wall_s':>9}  verdict")
+    header = (
+        f"{'d':>5} {'logZ_true':>12} {'logZ_est':>12} {'logZ_err':>10} "
+        f"{'|err|':>8} {'inner':>6} {'steps':>8} {'wall_s':>9}  verdict"
+    )
     print(header)
 
     rows = []
@@ -151,22 +179,26 @@ def main():
         abs_err = abs(est - logZ_true)
         ok = abs_err < max(3.0 * err, args.atol)
         all_ok &= ok
-        rows.append({
-            "d": d,
-            "logZ_true": logZ_true,
-            "logZ_est": est,
-            "logZ_err": err,
-            "abs_err": abs_err,
-            "num_inner_steps": res["num_inner_steps"],
-            "n_steps": int(res["n_steps"]),
-            "wall_s": res["wall_s"],
-            "num_live": args.num_live,
-            "num_delete": args.num_delete,
-            "ok": int(ok),
-        })
-        print(f"{d:>5} {logZ_true:>12.3f} {est:>12.3f} {err:>10.3f} "
-              f"{abs_err:>8.3f} {res['num_inner_steps']:>6d} {res['n_steps']:>8d} "
-              f"{res['wall_s']:>9.1f}  {'PASS' if ok else 'FAIL'}")
+        rows.append(
+            {
+                "d": d,
+                "logZ_true": logZ_true,
+                "logZ_est": est,
+                "logZ_err": err,
+                "abs_err": abs_err,
+                "num_inner_steps": res["num_inner_steps"],
+                "n_steps": int(res["n_steps"]),
+                "wall_s": res["wall_s"],
+                "num_live": args.num_live,
+                "num_delete": args.num_delete,
+                "ok": int(ok),
+            }
+        )
+        print(
+            f"{d:>5} {logZ_true:>12.3f} {est:>12.3f} {err:>10.3f} "
+            f"{abs_err:>8.3f} {res['num_inner_steps']:>6d} {res['n_steps']:>8d} "
+            f"{res['wall_s']:>9.1f}  {'PASS' if ok else 'FAIL'}"
+        )
 
     with open(args.out, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
@@ -177,11 +209,15 @@ def main():
     a_s, b_s = _fit_powerlaw(dims, [r["n_steps"] for r in rows])
     a_w, b_w = _fit_powerlaw(dims, [r["wall_s"] for r in rows])
     print("=" * 92)
-    print(f"Power-law fits:  n_steps ~ {a_s:.3g} * d^{b_s:.2f}   "
-          f"wall_s ~ {a_w:.3g} * d^{b_w:.2f}")
+    print(
+        f"Power-law fits:  n_steps ~ {a_s:.3g} * d^{b_s:.2f}   "
+        f"wall_s ~ {a_w:.3g} * d^{b_w:.2f}"
+    )
     print(f"CSV written: {args.out}")
-    print(f"Stage 1a evidence-accuracy gate: {'PASS' if all_ok else 'FAIL'} "
-          f"(exponent b_steps={b_s:.2f}, b_wall={b_w:.2f})")
+    print(
+        f"Stage 1a evidence-accuracy gate: {'PASS' if all_ok else 'FAIL'} "
+        f"(exponent b_steps={b_s:.2f}, b_wall={b_w:.2f})"
+    )
     raise SystemExit(0 if all_ok else 1)
 
 

--- a/workflows/ng15_sgwb_demo/scripts/ns_scaling_dimension.py
+++ b/workflows/ng15_sgwb_demo/scripts/ns_scaling_dimension.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+"""NS cost-scaling study — Stage 1a: pure-dimension scaling (likelihood-free).
+
+Measures how blackjax nested slice sampling scales with problem dimension ``d`` on an
+analytically-known target, decoupled entirely from the Kalman likelihood cost. This is the
+study's *early kill probe*: if the sampler's step-count / wall-clock blows up in pure
+dimension (or its logZ drifts from the closed form) we learn the full-PTA verdict here, on
+CPU, before spending any A100 time on Kalman runs.
+
+Target (identical to the T2.6 GATE-2 check, ``blackjax_ns_analytic_check.py``): an isotropic
+unit-Gaussian likelihood ``L(x)=N(x;0,I_d)`` under a uniform prior on the box ``[-B,B]^d``,
+so ``logZ_true = -d*log(2B)`` is known exactly. This mirrors ``run_dim`` there but exposes the
+``num_delete`` / ``num_live`` / ``num_inner_steps`` knobs (the analytic check hard-codes
+num_delete=1), so we can characterise the *same* engine core (``_blackjax_ns_evidence``) under
+the settings we would actually run at scale.
+
+We measure, per dimension:
+  - logZ accuracy: |logZ_est - logZ_true| vs the stochastic logZ_err  (evidence *correctness*)
+  - n_steps       : number of sequential NS iterations to reach dlogz  (the D-scaling cost)
+  - wall_s        : sampling wall-clock
+
+and fit power laws n_steps(d), wall_s(d). Writes a CSV for ns_scaling_analyze.py.
+
+Run (CPU, fast):
+    JAX_PLATFORMS=cpu PYTHONPATH=<repo>/python \
+        python workflows/ng15_sgwb_demo/scripts/ns_scaling_dimension.py \
+        --dims 2 5 15 30 60 --num-delete 25
+
+Exit code 0 iff every dimension's recovered logZ agrees with the closed form within
+tolerance (|logZ_est - logZ_true| < max(3*logZ_err, ATOL)); otherwise 1 (evidence became
+unreliable at some dimension — itself a study finding).
+"""
+import argparse
+import csv
+import math
+import os
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+jax.config.update("jax_enable_x64", True)
+
+from argus.bayesian_inference import _blackjax_ns_evidence  # noqa: E402
+
+DEFAULT_OUT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "outputs",
+    "scaling",
+)
+
+
+def run_dim(d, half_width=10.0, num_live=500, num_delete=25, num_inner_steps=None,
+            inner_mult=None, seed=0, dlogz=-5.0, max_steps=200000, kernel="nss"):
+    """Run NS on the d-dim analytic Gaussian; return (logZ_true, res).
+
+    Mirrors ``blackjax_ns_analytic_check.run_dim`` (same target, same known logZ) but with
+    the batch-deletion / live-point knobs exposed for the scaling sweep. ``inner_mult`` sets
+    num_inner_steps = inner_mult*d (overrides ``num_inner_steps``); the Stage-1a diagnostic
+    found the engine default of 2*d biases logZ at high d, while ~6*d recovers accuracy.
+    """
+    lo, hi = -half_width, half_width
+    log_box_volume = d * math.log(hi - lo)
+    logZ_true = -log_box_volume  # Gaussian integrates to ~1 over the wide box
+
+    def logprior_fn(x):
+        inside = jnp.all((x >= lo) & (x <= hi))
+        return jnp.where(inside, -log_box_volume, -jnp.inf)
+
+    def loglikelihood_fn(x):
+        return -0.5 * jnp.sum(x**2) - 0.5 * d * math.log(2.0 * math.pi)
+
+    if inner_mult is not None:
+        num_inner_steps = max(5, int(inner_mult * d))
+    elif num_inner_steps is None:
+        num_inner_steps = max(5, 2 * d)  # the engine's default; scales with d
+
+    key = jax.random.PRNGKey(seed)
+    key, subkey = jax.random.split(key)
+    init_particles = jax.random.uniform(subkey, (num_live, d), minval=lo, maxval=hi)
+
+    t0 = time.perf_counter()
+    res = _blackjax_ns_evidence(
+        logprior_fn,
+        loglikelihood_fn,
+        init_particles,
+        num_delete=num_delete,
+        num_inner_steps=num_inner_steps,
+        dlogz=dlogz,
+        max_steps=max_steps,
+        rng_key=key,
+        kernel=kernel,
+    )
+    res["wall_s"] = time.perf_counter() - t0
+    res["num_inner_steps"] = num_inner_steps
+    return logZ_true, res
+
+
+def _fit_powerlaw(x, y):
+    """Fit y ~ a * x^b in log-log; return (a, b) or (nan, nan) if degenerate."""
+    x = np.asarray(x, float)
+    y = np.asarray(y, float)
+    ok = (x > 0) & (y > 0)
+    if ok.sum() < 2:
+        return float("nan"), float("nan")
+    b, loga = np.polyfit(np.log(x[ok]), np.log(y[ok]), 1)
+    return float(np.exp(loga)), float(b)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dims", type=int, nargs="+",
+                        default=[2, 5, 15, 30, 60, 120, 270])
+    parser.add_argument("--num-live", type=int, default=500)
+    parser.add_argument("--num-delete", type=int, default=25)
+    parser.add_argument("--num-inner-steps", type=int, default=None,
+                        help="Fixed inner-step count; default engine's max(5, 2*d).")
+    parser.add_argument("--inner-mult", type=float, default=None,
+                        help="Set num_inner_steps = inner_mult*d (overrides --num-inner-steps). "
+                             "Stage-1a diagnostic: ~6 recovers logZ accuracy at high d.")
+    parser.add_argument("--dlogz", type=float, default=-5.0)
+    parser.add_argument("--atol", type=float, default=0.5)
+    parser.add_argument("--out", default=os.path.join(DEFAULT_OUT, "dimension_scaling.csv"))
+    args = parser.parse_args()
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+
+    print("=" * 92)
+    print("NS scaling Stage 1a: pure-dimension scaling (analytic Gaussian, likelihood-free)")
+    print(f"num_live={args.num_live}  num_delete={args.num_delete}  "
+          f"num_inner_steps={args.num_inner_steps or 'max(5,2d)'}  dlogz={args.dlogz}")
+    print("=" * 92)
+    header = (f"{'d':>5} {'logZ_true':>12} {'logZ_est':>12} {'logZ_err':>10} "
+              f"{'|err|':>8} {'inner':>6} {'steps':>8} {'wall_s':>9}  verdict")
+    print(header)
+
+    rows = []
+    all_ok = True
+    for d in args.dims:
+        logZ_true, res = run_dim(
+            d,
+            num_live=args.num_live,
+            num_delete=args.num_delete,
+            num_inner_steps=args.num_inner_steps,
+            inner_mult=args.inner_mult,
+            dlogz=args.dlogz,
+        )
+        est = res["logZ"]
+        err = res["logZ_err"]
+        abs_err = abs(est - logZ_true)
+        ok = abs_err < max(3.0 * err, args.atol)
+        all_ok &= ok
+        rows.append({
+            "d": d,
+            "logZ_true": logZ_true,
+            "logZ_est": est,
+            "logZ_err": err,
+            "abs_err": abs_err,
+            "num_inner_steps": res["num_inner_steps"],
+            "n_steps": int(res["n_steps"]),
+            "wall_s": res["wall_s"],
+            "num_live": args.num_live,
+            "num_delete": args.num_delete,
+            "ok": int(ok),
+        })
+        print(f"{d:>5} {logZ_true:>12.3f} {est:>12.3f} {err:>10.3f} "
+              f"{abs_err:>8.3f} {res['num_inner_steps']:>6d} {res['n_steps']:>8d} "
+              f"{res['wall_s']:>9.1f}  {'PASS' if ok else 'FAIL'}")
+
+    with open(args.out, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    dims = [r["d"] for r in rows]
+    a_s, b_s = _fit_powerlaw(dims, [r["n_steps"] for r in rows])
+    a_w, b_w = _fit_powerlaw(dims, [r["wall_s"] for r in rows])
+    print("=" * 92)
+    print(f"Power-law fits:  n_steps ~ {a_s:.3g} * d^{b_s:.2f}   "
+          f"wall_s ~ {a_w:.3g} * d^{b_w:.2f}")
+    print(f"CSV written: {args.out}")
+    print(f"Stage 1a evidence-accuracy gate: {'PASS' if all_ok else 'FAIL'} "
+          f"(exponent b_steps={b_s:.2f}, b_wall={b_w:.2f})")
+    raise SystemExit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/ng15_sgwb_demo/slurm_scripts/blackjax_ns_run.sh
+++ b/workflows/ng15_sgwb_demo/slurm_scripts/blackjax_ns_run.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# T2.6 GATE 3 — blackjax nested-sampling validation on 1x A100.
+#
+# Runs the blackjax NS evidence engine (sampler = blackjax) on MDC2 dataset_2b across
+# several seeds, so we can check (1) the NS posterior reproduces the NUTS baseline
+# (outputs/mdc2_smoke_wide/: log10_ha ~ -12.88, log10_gamma_a ~ -8.1) and (2) the
+# recovered logZ is reproducible across seeds. The GPU is the natural venue: Argus's joint
+# Kalman likelihood is ~seconds/eval on CPU (NS needs thousands of evals) but fast on A100.
+#
+# Submit:  sbatch workflows/ng15_sgwb_demo/slurm_scripts/blackjax_ns_run.sh
+#          sbatch workflows/ng15_sgwb_demo/slurm_scripts/blackjax_ns_run.sh "42 7 123"   # custom seeds
+#
+# Uses the `Argus` conda env, which has blackjax installed from blackjax-devs main
+# (blackjax.nss; the PyPI wheels lack the NS module) alongside the pinned jax 0.4.38.
+# run_blackjax_nested_sampling shims jax.shard_map so `import blackjax` works on 0.4.38.
+
+#SBATCH --job-name=bjax_ns
+#SBATCH --account=oz022
+# A100 GPU jobs on oz022 route to milan-gpu regardless of requested partition (job_submit
+# plugin canonicalizes it); if milan-gpu is down, GPU jobs queue (Reason=PartitionDown).
+#SBATCH --partition=milan-gpu
+#SBATCH --gres=gpu:1
+#SBATCH --time=2:00:00
+#SBATCH --mem=16G
+#SBATCH --cpus-per-task=4
+#SBATCH --export=ALL
+#SBATCH --chdir=/home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/ng15_sgwb_demo
+#SBATCH --output=/home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/ng15_sgwb_demo/outputs/logfiles/bjax_ns_%j.out
+
+# NB: no `set -e` -- sourcing ~/.bashrc / conda init returns non-zero in a
+# non-interactive shell, which under `set -e` aborts the job before any output.
+
+ROOT=/home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/ng15_sgwb_demo
+WORKTREE_PY=/home/tkimpson/.treehouse/Argus-891104/1/Argus/python
+
+SEEDS="${1:-42 7 123}"
+
+mkdir -p "${ROOT}/outputs/derived_configs" "${ROOT}/outputs/logfiles"
+
+source ~/.bashrc
+conda activate /fred/oz022/tkimpson/conda_envs/Argus
+
+# CRITICAL: argus is pip-installed EDITABLE pointing at /fred/oz022/tkimpson/Argus (the main
+# checkout, which lacks the T2.6 blackjax backend). run_analysis.py only sys.path.append()s
+# the repo python/ dir, which loses to the editable install. Prepend THIS worktree's python/
+# via PYTHONPATH so `import argus` resolves to the patched code.
+export PYTHONPATH="${WORKTREE_PY}:${PYTHONPATH}"
+
+echo "=== env check ==="
+which python
+python -c "import jax; print('jax', jax.__version__)"
+python -c "import argus.bayesian_inference as bi; print('run_blackjax_nested_sampling:', hasattr(bi,'run_blackjax_nested_sampling'))"
+python -c "import argus.bayesian_inference as bi; bj=bi._import_blackjax_ns(); print('blackjax', bj.__version__, 'nss:', hasattr(bj,'nss'))"
+nvidia-smi -L
+
+for SEED in ${SEEDS}; do
+  OUTID="mdc2_blackjax_ns_s${SEED}"
+  RUN="${ROOT}/outputs/derived_configs/run_bjax_s${SEED}.ini"
+  # Line-anchored sed only touches the seed / output_id lines (comments left intact).
+  sed -e "s|^seed = .*|seed = ${SEED}|" \
+      -e "s|^output_id = .*|output_id = ${OUTID}|" \
+      "${ROOT}/configs/mdc2_blackjax_ns.ini" > "${RUN}"
+  echo "=== running blackjax NS (seed=${SEED}) -> ${OUTID} ==="
+  grep -E "^seed|^output_id|^sampler|^num_live_points" "${RUN}"
+  time python -u "${ROOT}/run_analysis.py" "${RUN}"
+done
+
+echo "=== all seeds done ==="

--- a/workflows/ng15_sgwb_demo/slurm_scripts/ns_microbench_run.sh
+++ b/workflows/ng15_sgwb_demo/slurm_scripts/ns_microbench_run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# NS scaling study — Stage 1b (revised): Kalman likelihood cost vs N, on 1x A100.
+# Direct microbenchmark of the likelihood NS evaluates, at sane params (no NS, no pathology).
+# Submit:  sbatch workflows/ng15_sgwb_demo/slurm_scripts/ns_microbench_run.sh
+#SBATCH --job-name=ns_ubench
+#SBATCH --account=oz022
+#SBATCH --partition=milan-gpu
+#SBATCH --gres=gpu:1
+#SBATCH --time=00:40:00
+#SBATCH --mem=32G
+#SBATCH --cpus-per-task=4
+#SBATCH --export=ALL
+#SBATCH --chdir=/home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/ng15_sgwb_demo
+#SBATCH --output=/home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/ng15_sgwb_demo/outputs/logfiles/ns_ubench_%j.out
+
+ROOT=/home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/ng15_sgwb_demo
+WORKTREE_PY=/home/tkimpson/.treehouse/Argus-891104/1/Argus/python
+
+source ~/.bashrc
+conda activate /fred/oz022/tkimpson/conda_envs/Argus
+export PYTHONPATH="${WORKTREE_PY}:${PYTHONPATH}"   # editable-install fix (see blackjax_ns_run.sh)
+
+echo "=== env check ==="; which python; python -c "import jax; print('jax', jax.__version__)"; nvidia-smi -L
+echo "=== microbench N=2,4,8,16,32 ==="
+python -u "${ROOT}/scripts/ns_likelihood_microbench.py" --N 2 4 8 16 32 --batch 25 --repeats 30 \
+  --out "${ROOT}/outputs/scaling/likelihood_cost_vs_N.csv"
+echo "=== done ==="

--- a/workflows/ng15_sgwb_demo/slurm_scripts/ns_scaling_run.sh
+++ b/workflows/ng15_sgwb_demo/slurm_scripts/ns_scaling_run.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# NS cost-scaling study — GPU runner for stages 1b / 2 / 3 (1x A100 per grid point).
+#
+# Two modes:
+#   1. SUBMIT (run on the login node):
+#          bash ns_scaling_run.sh submit 1b            # default walltime for the stage
+#          bash ns_scaling_run.sh submit 2  48:00:00   # override walltime (HH:MM:SS)
+#      Generates the stage's derived configs (gen_scaling_configs.py), writes a config-list
+#      file, and submits a SLURM job ARRAY with one task per config (each task = one A100
+#      job, so each grid point is independently time-boxed and queued).
+#   2. WORKER (invoked by SLURM inside the array): reads its config from ${CONFIG_LIST} at
+#      line ${SLURM_ARRAY_TASK_ID} and runs it via run_analysis.py. Not called by hand.
+#
+# Mirrors blackjax_ns_run.sh: same env, same critical PYTHONPATH editable-install fix,
+# A100/oz022 routing. Runtime + n_steps land in each run's {output_id}_evidence.json
+# (Stage-0 instrumentation); the shell `time` (total job wall) goes to the slurm .out.
+
+#SBATCH --job-name=ns_scal
+#SBATCH --account=oz022
+# A100 GPU jobs on oz022 route to milan-gpu regardless of requested partition.
+#SBATCH --partition=milan-gpu
+#SBATCH --gres=gpu:1
+#SBATCH --mem=32G
+#SBATCH --cpus-per-task=4
+#SBATCH --export=ALL
+#SBATCH --chdir=/home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/ng15_sgwb_demo
+#SBATCH --output=/home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/ng15_sgwb_demo/outputs/logfiles/ns_scal_%A_%a.out
+
+ROOT=/home/tkimpson/.treehouse/Argus-891104/1/Argus/workflows/ng15_sgwb_demo
+WORKTREE_PY=/home/tkimpson/.treehouse/Argus-891104/1/Argus/python
+ENVPY=/fred/oz022/tkimpson/conda_envs/Argus
+
+# ---------------------------------------------------------------- SUBMIT mode
+if [ "$1" = "submit" ]; then
+  STAGE="$2"
+  if [ -z "${STAGE}" ]; then echo "usage: $0 submit <1b|2|3> [walltime]"; exit 1; fi
+  # Sensible per-stage default walltimes (D=2 is fast; high-D coupled runs are long).
+  case "${STAGE}" in
+    1b) DEF_TIME="04:00:00" ;;
+    2)  DEF_TIME="48:00:00" ;;   # escalate if a high-D point is close to the wall
+    3)  DEF_TIME="24:00:00" ;;
+    *)  echo "unknown stage ${STAGE}"; exit 1 ;;
+  esac
+  WALLTIME="${3:-${DEF_TIME}}"
+
+  mkdir -p "${ROOT}/outputs/derived_configs" "${ROOT}/outputs/logfiles"
+  LIST="${ROOT}/outputs/derived_configs/list_stage${STAGE}.txt"
+
+  # Generate configs (pure python); stdout = config paths (one per line), stderr = summary.
+  "${ENVPY}/bin/python" "${ROOT}/scripts/gen_scaling_configs.py" --stage "${STAGE}" > "${LIST}"
+  N=$(wc -l < "${LIST}")
+  if [ "${N}" -eq 0 ]; then echo "no configs generated"; exit 1; fi
+  echo "stage ${STAGE}: ${N} configs -> ${LIST}; submitting array 1-${N}, time=${WALLTIME}"
+  # Array is 1-indexed to match sed line numbers below.
+  sbatch --array=1-"${N}" --time="${WALLTIME}" \
+         --export=ALL,CONFIG_LIST="${LIST}" \
+         "${ROOT}/slurm_scripts/ns_scaling_run.sh"
+  exit $?
+fi
+
+# ---------------------------------------------------------------- WORKER mode (under SLURM)
+if [ -z "${SLURM_ARRAY_TASK_ID}" ]; then
+  echo "not in a SLURM array and no 'submit' arg; see header for usage."; exit 1
+fi
+
+source ~/.bashrc
+conda activate "${ENVPY}"
+
+# CRITICAL (see blackjax_ns_run.sh): argus is pip-installed EDITABLE at the main checkout,
+# which lacks this worktree's engine/instrumentation. Prepend the worktree python/ so
+# `import argus` resolves to the patched code.
+export PYTHONPATH="${WORKTREE_PY}:${PYTHONPATH}"
+
+CONFIG=$(sed -n "${SLURM_ARRAY_TASK_ID}p" "${CONFIG_LIST}")
+echo "=== env check ==="
+which python
+python -c "import jax; print('jax', jax.__version__)"
+python -c "import argus; print('argus', argus.__file__)"
+nvidia-smi -L
+echo "=== running NS scaling config: ${CONFIG} ==="
+grep -E "^excluded_psrs|^num_live_points|^num_delete|^num_inner_steps|^output_id|^spin_injections_path|^noise_params_path" "${CONFIG}"
+time python -u "${ROOT}/run_analysis.py" "${CONFIG}"
+echo "=== done: ${CONFIG} ==="


### PR DESCRIPTION
## Summary

W0.2 of the real-data roadmap (#111): the nested-sampling half of PR #106, split out as a citable reference record. Not on the critical path — this documents the T2.6 blackjax-NS feasibility spike (PASS: analytic logZ correct, MDC2 posterior reproduces NUTS) and the 2026-07-10 decision to **park slice nested sampling** as the production evidence engine (~10–30× slower than NUTS at matched accuracy; evidence now comes from the learned harmonic mean, see `logz_lhm.py` in #113).

Contents:
- **Library engine** (moved here from #113 so `main` only gains parked NS code if this PR merges): `bayesian_inference._import_blackjax_ns` / `_blackjax_ns_evidence` / `run_blackjax_nested_sampling`, and `workflow`'s `sampler=blackjax` dispatch with the `ns_meta` cost-scaling payload.
- **Notes / verdicts**: `DECISION_nested_sampling_parked.md`, `t2.6_blackjax_ns_verdict.md`, `ns_numerical_hygiene.md` (the near-singular-covariance pathology NS exposed, fixed on `main` via #102), and the strategy evaluation `research-evaluations/2026-07-09-blackjax-nested-sampling-model-selection.md`.
- **Scripts**: `blackjax_ns_analytic_check.py` (analytic logZ gate), the NS cost-scaling study (`ns_scaling_dimension.py`, `ns_kernel_compare.py`, `ns_likelihood_microbench.py`, `ns_pathology_probe.py`, `ns_scaling_analyze.py`, `gen_scaling_configs.py`).
- **Configs / SLURM**: `mdc2_blackjax_ns.ini`, `blackjax_ns_run.sh`, `ns_scaling_run.sh`, `ns_microbench_run.sh`.

## Dependencies

Stacked on #113 (base branch `w0.1-pipeline-extraction`); retarget/rebase onto `main` once #113 merges. Environment caveat (recorded in the verdict note): blackjax-devs main installed `--no-deps` on the pinned jax 0.4.38 with a `jax.shard_map` shim.

## Test plan

- [x] Full suite green with the engine present (258 passed, 1 pre-existing data skip) — the engine imports blackjax lazily, so the pinned env is unaffected until `sampler=blackjax` is actually requested.

Refs #111. Extracted from #106.
